### PR TITLE
GetEntries() Returns Tuple

### DIFF
--- a/Assets/SpacetimeDB/Scripts/ClientCache.cs
+++ b/Assets/SpacetimeDB/Scripts/ClientCache.cs
@@ -159,7 +159,7 @@ namespace SpacetimeDB
             }
         }
 
-        public IEnumerable<AlgebraicValue> GetEntries(string name)
+        public IEnumerable<(AlgebraicValue, object)> GetEntries(string name)
         {
             if (!tables.TryGetValue(name, out var table))
             {
@@ -168,7 +168,7 @@ namespace SpacetimeDB
 
             foreach (var entry in table.entries)
             {
-                yield return entry.Value.Item1;
+                yield return entry.Value;
             }
         }
 


### PR DESCRIPTION
`GetEntries()` now returns a tuple. This is required for the change to make `Iter()` not deserialize each `AlgebraicValue` and instead use the value we have already parsed.
