### PR TITLE
State Diffs

### DIFF
--- a/Assets/SpacetimeDB/Scripts/NetworkManager.cs
+++ b/Assets/SpacetimeDB/Scripts/NetworkManager.cs
@@ -154,7 +154,7 @@ namespace SpacetimeDB
             }
 
             // cache all our reducer events by their function name 
-            foreach (var methodInfo in typeof(Bitcraft.Reducer).GetMethods())
+            foreach (var methodInfo in typeof(Reducer).GetMethods())
             {
                 if (methodInfo.GetCustomAttribute<ReducerEvent>() is
                     { } reducerEvent)
@@ -179,7 +179,7 @@ namespace SpacetimeDB
             public IList<DbEvent> events;
         }
 
-        private readonly BlockingCollection<byte[]> _messageQueue = new(new ConcurrentQueue<byte[]>());
+        private readonly BlockingCollection<byte[]> _messageQueue = new BlockingCollection<byte[]>(new ConcurrentQueue<byte[]>());
         private ProcessedMessage? nextMessage;
 
         void ProcessMessages()

--- a/Assets/SpacetimeDB/Scripts/Reducer.cs
+++ b/Assets/SpacetimeDB/Scripts/Reducer.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Bitcraft
+namespace SpacetimeDB
 {
     public partial class Reducer
     {


### PR DESCRIPTION
## Description

When a client subscribes to a dataset, then subscribes to a new dataset we just send the new dataset. We don't do any state diffs on the server right now, so this PR introduces state diffs for the client so we can see what has actually changed and only send relevant callbacks to the client.
