### PR TITLE
Fixed occasional double insert

### DIFF
--- a/Assets/SpacetimeDB/Scripts/NetworkManager.cs
+++ b/Assets/SpacetimeDB/Scripts/NetworkManager.cs
@@ -252,22 +252,6 @@ namespace SpacetimeDB
                                 switch (row.Op)
                                 {
                                     case TableRowOperation.Types.OperationType.Delete:
-                                        // If we don't already have this row, we should skip this delete
-                                        if (!table.entries.ContainsKey(rowPk))
-                                        {
-                                            if (update.TableRowOperations.Any(
-                                                    a => a.RowPk.ToByteArray().SequenceEqual(rowPk)))
-                                            {
-                                                // Debug.LogWarning("We are deleting and inserting the same row in the same TX!");
-                                            }
-                                            else
-                                            {
-                                                Debug.LogWarning(
-                                                    $"We received a delete for a row we don't even subscribe to! table={table.Name}");
-                                            }
-                                            continue;
-                                        }
-
                                         dbEvents.Add(new DbEvent
                                         {
                                             table = table,


### PR DESCRIPTION
- Fixed occasional double insert due to multithreading. If a message is getting deserialized while another thread is running an update on that entity (delete followed by an update) there was a change deserializing thread would've thought we were trying to delete an entity that doesn't exist and ignore the delete that would've changed insert into an update
- This code block also would've been a problem in other cases since it doesn't take into account pending transactions
- This check is also unnecessary as a similar check is performed on main thread