### PR TITLE
Fixed Serialization Issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ $RECYCLE.BIN/
 .DS_Store
 
 _NCrunch*
+
+# JetBrains Ignore
+.idea/

--- a/src/json/EnumWrapperConverter.cs
+++ b/src/json/EnumWrapperConverter.cs
@@ -24,7 +24,7 @@ namespace SpacetimeDB
         {
             writer.WriteStartObject();
             writer.WritePropertyName(value.ToString());
-            writer.WriteRaw("{}");
+            writer.WriteRawValue("{}");
             writer.WriteEndObject();
 
         }

--- a/src/json/JsonContractResolver.cs
+++ b/src/json/JsonContractResolver.cs
@@ -30,7 +30,7 @@ namespace SpacetimeDB
         }
     }
     
-public class EnumConverter : JsonConverter
+    public class EnumConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType) => true;
 
@@ -44,12 +44,12 @@ public class EnumConverter : JsonConverter
         {
             writer.WriteStartObject();
             writer.WritePropertyName(value.ToString());
-            writer.WriteRaw("{}");
+            writer.WriteRawValue("{}");
             writer.WriteEndObject();
         }
     }
     
-public class JsonContractResolver : DefaultContractResolver
+    public class JsonContractResolver : DefaultContractResolver
     {
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {


### PR DESCRIPTION
# Description

This fixes an issue where "null" was being put into a serialized enum value, like this:

```
enum MyEnum {
  Item,
  Cargo
}

enum_value: {"Item": {}null}
```

This PR fixes the serialization so it ends up in the correct representation:
```
enum_value: {"Item": {}}
```


