### PR TITLE
generate types to SpacetimeDB.Types namespace

### DIFF
--- a/src/ReducerExtensions.cs
+++ b/src/ReducerExtensions.cs
@@ -2,6 +2,10 @@
 
 namespace SpacetimeDB
 {
+    public class ReducerClassAttribute : Attribute
+    {
+    }
+
     public class ReducerCallbackAttribute : Attribute
     {
         public string FunctionName { get; set; }

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -123,16 +123,15 @@ namespace SpacetimeDB
                 // Get all types in the assembly
                 Type[] types = assembly.GetTypes();
 
-                // Search for the type by name and namespace
-                Type targetType = types.FirstOrDefault(t =>
-                    t.Name == "Reducer" &&
-                    t.Namespace == "SpacetimeDB.Types");
-
-                // If the type is found, return it
-                if (targetType != null)
+                // Search for the class with the attribute ReducerClass
+                foreach (Type type in types)
                 {
-                    return targetType;
+                    if (type.GetCustomAttribute<ReducerClassAttribute>() != null)
+                    {
+                        return type;
+                    }
                 }
+
             }
 
             // If the type is not found in any assembly, return null or throw an exception


### PR DESCRIPTION
The associated SpacetimeDB PR is already merged

This fixes name collisions

NOTE: This will break existing CSharp projects and Unity projects when they update.