### PR TITLE
Use correct hashcode for identity

### DIFF
--- a/src/Identity.cs
+++ b/src/Identity.cs
@@ -70,5 +70,10 @@ namespace SpacetimeDB
 
             return BitConverter.ToInt32(bytes, 0);
         }
+
+        public override string ToString()
+        {
+            return string.Concat(bytes.Select(b => b.ToString("x2")));
+        }
     }
 }


### PR DESCRIPTION
Use the first 4 bytes of the identity to generate a hashcode instead of default object.GetHashCode