### PR TITLE
Performance improvement for Del/Ins -> Update conversion

### DIFF
--- a/src/ClientCache.cs
+++ b/src/ClientCache.cs
@@ -62,6 +62,8 @@ namespace SpacetimeDB
             // TODO: Consider renaming this one, this kind of implies that its a callback for the Update operation
             public Action<SpacetimeDBClient.TableOp, object, object, ClientApi.Event> RowUpdatedCallback;
             public Func<AlgebraicType, AlgebraicValue, AlgebraicValue, bool> ComparePrimaryKeyFunc;
+            public Func<AlgebraicValue, AlgebraicValue> GetPrimaryKeyValueFunc;
+            public Func<AlgebraicType, AlgebraicType> GetPrimaryKeyTypeFunc;
 
             public string Name
             {
@@ -90,6 +92,10 @@ namespace SpacetimeDB
                     ?.CreateDelegate(typeof(Action<SpacetimeDBClient.TableOp, object, object, ClientApi.Event>));
                 ComparePrimaryKeyFunc = (Func<AlgebraicType, AlgebraicValue, AlgebraicValue, bool>)clientTableType.GetMethod("ComparePrimaryKey", BindingFlags.Static | BindingFlags.Public)
                     ?.CreateDelegate(typeof(Func<AlgebraicType, AlgebraicValue, AlgebraicValue, bool>));
+                GetPrimaryKeyValueFunc = (Func<AlgebraicValue, AlgebraicValue>)clientTableType.GetMethod("GetPrimaryKeyValue", BindingFlags.Static | BindingFlags.Public)
+                    ?.CreateDelegate(typeof(Func<AlgebraicValue, AlgebraicValue>));
+                GetPrimaryKeyTypeFunc = (Func<AlgebraicType, AlgebraicType>)clientTableType.GetMethod("GetPrimaryKeyType", BindingFlags.Static | BindingFlags.Public)
+                    ?.CreateDelegate(typeof(Func<AlgebraicType, AlgebraicType>));
                 entries = new Dictionary<byte[], (AlgebraicValue, object)>(new ByteArrayComparer());
                 decodedValues = new ConcurrentDictionary<byte[], (AlgebraicValue, object)>(new ByteArrayComparer());
             }
@@ -210,6 +216,16 @@ namespace SpacetimeDB
             public bool ComparePrimaryKey(AlgebraicValue v1, AlgebraicValue v2)
             {
                 return (bool)ComparePrimaryKeyFunc.Invoke(rowSchema, v1, v2);
+            }
+
+            public AlgebraicValue GetPrimaryKeyValue(AlgebraicValue row)
+            {
+                return GetPrimaryKeyValueFunc.Invoke(row);
+            }
+
+            public AlgebraicType GetPrimaryKeyType(AlgebraicType row)
+            {
+                return GetPrimaryKeyTypeFunc.Invoke(row);
             }
 
             public bool ComparePrimaryKey(byte[] rowPk1, byte[] rowPk2)

--- a/src/SATS/AlgebraicValue.cs
+++ b/src/SATS/AlgebraicValue.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.IO;
 
@@ -25,7 +26,7 @@ namespace SpacetimeDB.SATS
         public string AsString() => (string)value;
         public List<AlgebraicValue> AsArray() => (List<AlgebraicValue>)value;
         public Dictionary<AlgebraicValue, AlgebraicValue> AsMap() => (Dictionary<AlgebraicValue, AlgebraicValue>)value;
-        
+
         public static BuiltinValue CreateBool(bool value) => new BuiltinValue { value = value };
         public static BuiltinValue CreateI8(sbyte value) => new BuiltinValue { value = value };
         public static BuiltinValue CreateU8(byte value) => new BuiltinValue { value = value };
@@ -198,18 +199,18 @@ namespace SpacetimeDB.SATS
 
                     return CreateArray(arrayResult);
                 case BuiltinType.Type.Map:
-                {
-                    var len = reader.ReadUInt32();
-                    var mapResult = new Dictionary<AlgebraicValue, AlgebraicValue>();
-                    for (var x = 0; x < len; x++)
                     {
-                        var key = AlgebraicValue.Deserialize(type.mapType.keyType, reader);
-                        var value = AlgebraicValue.Deserialize(type.mapType.valueType, reader);
-                        mapResult.Add(key, value);
-                    }
+                        var len = reader.ReadUInt32();
+                        var mapResult = new Dictionary<AlgebraicValue, AlgebraicValue>();
+                        for (var x = 0; x < len; x++)
+                        {
+                            var key = AlgebraicValue.Deserialize(type.mapType.keyType, reader);
+                            var value = AlgebraicValue.Deserialize(type.mapType.valueType, reader);
+                            mapResult.Add(key, value);
+                        }
 
-                    return CreateMap(mapResult);
-                }
+                        return CreateMap(mapResult);
+                    }
                 default:
                     throw new NotImplementedException();
             }
@@ -345,7 +346,7 @@ namespace SpacetimeDB.SATS
 
             for (var i = 0; i < type.elements.Count; i++)
             {
-                if(!AlgebraicValue.Compare(type.elements[i].algebraicType, v1.elements[i], v2.elements[i]))
+                if (!AlgebraicValue.Compare(type.elements[i].algebraicType, v1.elements[i], v2.elements[i]))
                 {
                     return false;
                 }
@@ -420,7 +421,7 @@ namespace SpacetimeDB.SATS
                     throw new NotImplementedException();
             }
         }
-        
+
         public static AlgebraicValue Deserialize(AlgebraicType type, BinaryReader reader)
         {
             switch (type.type)
@@ -453,5 +454,33 @@ namespace SpacetimeDB.SATS
                     throw new NotImplementedException();
             }
         }
+
+        public class AlgebraicValueComparer : IEqualityComparer<AlgebraicValue>
+        {
+            private AlgebraicType type;
+            public AlgebraicValueComparer(AlgebraicType type)
+            {
+                this.type = type;
+            }
+
+            public bool Equals(AlgebraicValue l, AlgebraicValue r)
+            {
+                return AlgebraicValue.Compare(type, l, r);
+            }
+
+            public int GetHashCode(AlgebraicValue value)
+            {
+                var stream = new MemoryStream();
+                var writer = new BinaryWriter(stream);
+                value.Serialize(type, writer);
+                var s = stream.ToArray();
+                if (s.Length >= 4)
+                {
+                    return BitConverter.ToInt32(s, 0);
+                }
+                return s.Sum(b => b);
+            }
+        }
+
     }
 }

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -1,16 +1,17 @@
 using System;
-using System.Linq;
-using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Net.WebSockets;
 using System.Reflection;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using ClientApi;
 using Newtonsoft.Json;
 using SpacetimeDB.SATS;
-using System.Threading;
-using System.IO;
-using System.Threading.Tasks;
+using UnityEngine;
 
 namespace SpacetimeDB
 {
@@ -34,7 +35,7 @@ namespace SpacetimeDB
             public string subscriptionQuery;
         }
 
-        public struct DbEvent
+        public struct DbOp
         {
             public ClientCache.TableCache table;
             public TableOp op;
@@ -42,6 +43,7 @@ namespace SpacetimeDB
             public object oldValue;
             public byte[] deletedPk;
             public byte[] insertedPk;
+            public AlgebraicValue primaryKeyValue;
         }
 
         public delegate void RowUpdate(string tableName, TableOp op, object oldValue, object newValue, SpacetimeDB.ReducerEventBase dbEvent);
@@ -54,7 +56,7 @@ namespace SpacetimeDB
         /// <summary>
         /// Called when a connection attempt fails.
         /// </summary>
-        public event Action<WebSocketError?, string?> onConnectError;
+        public event Action<WebSocketError?> onConnectError;
 
         /// <summary>
         /// Called when an exception occurs when sending a message.
@@ -88,23 +90,23 @@ namespace SpacetimeDB
 
         private SpacetimeDB.WebSocket webSocket;
         private bool connectionClosed;
-        public static ClientCache clientDB; 
+        public static ClientCache clientDB;
         public static Dictionary<string, Func<ClientApi.Event, bool>> reducerEventCache = new Dictionary<string, Func<ClientApi.Event, bool>>();
         public static Dictionary<string, Action<ClientApi.Event>> deserializeEventCache = new Dictionary<string, Action<ClientApi.Event>>();
 
-        private bool isClosing;
         private Thread messageProcessThread;
 
         public static SpacetimeDBClient instance;
 
         public ISpacetimeDBLogger Logger => logger;
-        private ISpacetimeDBLogger logger;        
+        private ISpacetimeDBLogger logger;
 
-        public static void CreateInstance(ISpacetimeDBLogger loggerToUse)
+
+        public static void CreateInstance(ISpacetimeDBLogger loggerToUse, Type reducerType)
         {
             if (instance == null)
             {
-                new SpacetimeDBClient(loggerToUse);
+                new SpacetimeDBClient(loggerToUse, reducerType);
             }
             else
             {
@@ -112,35 +114,7 @@ namespace SpacetimeDB
             }
         }
 
-        public Type FindReducerType()
-        {
-            // Get all loaded assemblies
-            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
-
-            // Iterate over each assembly and search for the type
-            foreach (Assembly assembly in assemblies)
-            {
-                // Get all types in the assembly
-                Type[] types = assembly.GetTypes();
-
-                // Search for the type by name and namespace
-                Type targetType = types.FirstOrDefault(t =>
-                    t.Name == "Reducer" &&
-                    t.Namespace == "SpacetimeDB");
-
-                // If the type is found, return it
-                if (targetType != null)
-                {
-                    return targetType;
-                }
-            }
-
-            // If the type is not found in any assembly, return null or throw an exception
-            return null;
-        }
-
-
-        protected SpacetimeDBClient(ISpacetimeDBLogger loggerToUse)
+        protected SpacetimeDBClient(ISpacetimeDBLogger loggerToUse, Type reducerType)
         {
             if (instance != null)
             {
@@ -162,7 +136,7 @@ namespace SpacetimeDB
             webSocket.OnMessage += OnMessageReceived;
             webSocket.OnClose += (code, error) => onDisconnect?.Invoke(code, error);
             webSocket.OnConnect += () => onConnect?.Invoke();
-            webSocket.OnConnectError += (a,b) => onConnectError?.Invoke(a,b);
+            webSocket.OnConnectError += a => onConnectError?.Invoke(a);
             webSocket.OnSendError += a => onSendError?.Invoke(a);
 
             clientDB = new ClientCache();
@@ -188,9 +162,6 @@ namespace SpacetimeDB
                                   a => { return conversionFunc!.Invoke(null, new object[] { a }); });
             }
 
-            var reducerType = FindReducerType();
-            if (reducerType != null)
-            {
             // cache all our reducer events by their function name 
             foreach (var methodInfo in reducerType.GetMethods())
             {
@@ -205,14 +176,7 @@ namespace SpacetimeDB
                 {
                     deserializeEventCache.Add(deserializeEvent.FunctionName, (Action<ClientApi.Event>)methodInfo.CreateDelegate(typeof(Action<ClientApi.Event>)));
                 }
-                }
             }
-            else
-            {
-                loggerToUse.LogError($"Could not find reducer type. Have you run spacetime generate?");
-            }
-
-            _cancellationToken = _cancellationTokenSource.Token;
 
             messageProcessThread = new Thread(ProcessMessages);
             messageProcessThread.Start();
@@ -221,41 +185,33 @@ namespace SpacetimeDB
         struct ProcessedMessage
         {
             public Message message;
-            public IList<DbEvent> events;
+            public IList<DbOp> dbOps;
         }
 
         private readonly BlockingCollection<byte[]> _messageQueue = new BlockingCollection<byte[]>(new ConcurrentQueue<byte[]>());
         private readonly BlockingCollection<ProcessedMessage> _nextMessageQueue = new BlockingCollection<ProcessedMessage>(new ConcurrentQueue<ProcessedMessage>());
 
-        CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
-        CancellationToken _cancellationToken;
-
         void ProcessMessages()
         {
-            while (!isClosing)
+            while (true)
             {
-                try
+                var bytes = _messageQueue.Take();
+                var (m, dbOps) = PreProcessMessage(bytes);
+                var processedMessage = new ProcessedMessage
                 {
-                    var bytes = _messageQueue.Take(_cancellationToken);
-
-                    var (m, events) = PreProcessMessage(bytes);
-                    var processedMessage = new ProcessedMessage
-                    {
-                        message = m,
-                        events = events,
-                    };
-                    _nextMessageQueue.Add(processedMessage);
-                }
-                catch(OperationCanceledException)
-                {
-                    // Normal shutdown
-                    return;
-                }
+                    message = m,
+                    dbOps = dbOps,
+                };
+                _nextMessageQueue.Add(processedMessage);
             }
 
-            (Message, List<DbEvent>) PreProcessMessage(byte[] bytes)
+            (Message, List<DbOp>) PreProcessMessage(byte[] bytes)
             {
-                var dbEvents = new List<DbEvent>();
+                var dbOps = new List<DbOp>();
+
+                // Used when convering matching Insert/Delete ops into Update
+                var insertOps = new List<DbOp>();
+
                 var message = ClientApi.Message.Parser.ParseFrom(bytes);
                 using var stream = new MemoryStream();
                 using var reader = new BinaryReader(stream);
@@ -286,6 +242,9 @@ namespace SpacetimeDB
                                 continue;
                             }
 
+                            var primaryKeyType = table.GetPrimaryKeyType(table.RowSchema);
+                            var deleteOps = new Dictionary<AlgebraicValue, DbOp>(new AlgebraicValue.AlgebraicValueComparer(primaryKeyType));
+                            insertOps.Clear();
                             foreach (var row in update.TableRowOperations)
                             {
                                 var rowPk = row.RowPk.ToByteArray();
@@ -294,85 +253,100 @@ namespace SpacetimeDB
                                 stream.Write(rowValue, 0, rowValue.Length);
                                 stream.Position = 0;
                                 stream.SetLength(rowValue.Length);
-
-                                switch (row.Op)
+                                var decodedRow = AlgebraicValue.Deserialize(table.RowSchema, reader);
+                                if (decodedRow == null)
                                 {
-                                    case TableRowOperation.Types.OperationType.Delete:
-                                        dbEvents.Add(new DbEvent
-                                        {
-                                            table = table,
-                                            deletedPk = rowPk,
-                                            op = TableOp.Delete,
-                                            newValue = null,
-                                            // We cannot grab the old value here because there might be other
-                                            // pending operations that will execute before us. We should only
-                                            // set this value on the main thread where we know there are no other
-                                            // operations which could remove this value.
-                                            oldValue = null,
-                                        });
-                                        break;
-                                    case TableRowOperation.Types.OperationType.Insert:
-                                        // If we already have this row, we can ignore it
-                                        if (table.entries.ContainsKey(rowPk))
-                                        {
-                                            continue;
-                                        }
+                                    throw new Exception("Failed to deserialize row");
+                                }
 
-                                        var algebraicValue = AlgebraicValue.Deserialize(table.RowSchema, reader);
-                                        if(algebraicValue == null)
-                                        {
-                                            throw new Exception("Failed to deserialize row");
-                                        }
-                                        table.SetDecodedValue(rowPk, algebraicValue, out var obj);
-                                        dbEvents.Add(new DbEvent
-                                        {
-                                            table = table,
-                                            insertedPk = rowPk,
-                                            op = TableOp.Insert,
-                                            newValue = obj,
-                                            oldValue = null,
-                                        });
-                                        break;
+                                DbOp dbOp;
+                                AlgebraicValue primaryKeyValue = table.GetPrimaryKeyValue(decodedRow);
+                                if (row.Op == TableRowOperation.Types.OperationType.Delete)
+                                {
+                                    dbOp = new DbOp
+                                    {
+                                        table = table,
+                                        deletedPk = rowPk,
+                                        op = TableOp.Delete,
+                                        newValue = null,
+                                        // We cannot grab the old value here because there might be other
+                                        // pending operations that will execute before us. We should only
+                                        // set this value on the main thread where we know there are no other
+                                        // operations which could remove this value.
+                                        oldValue = null,
+                                        primaryKeyValue = primaryKeyValue
+                                    };
+                                }
+                                else
+                                {
+                                    // Skip this insert if we already have it
+                                    if (table.entries.ContainsKey(rowPk))
+                                    {
+                                        continue;
+                                    }
+
+                                    table.SetDecodedValue(rowPk, decodedRow, out var obj);
+                                    dbOp = new DbOp
+                                    {
+                                        table = table,
+                                        insertedPk = rowPk,
+                                        op = TableOp.Insert,
+                                        newValue = obj,
+                                        oldValue = null,
+                                        primaryKeyValue = primaryKeyValue
+                                    };
+                                }
+
+                                if (primaryKeyType != null)
+                                {
+                                    if (row.Op == TableRowOperation.Types.OperationType.Delete)
+                                    {
+                                        deleteOps[primaryKeyValue] = dbOp;
+                                    }
+                                    else
+                                    {
+                                        insertOps.Add(dbOp);
+                                    }
+                                }
+                                else
+                                {
+                                    dbOps.Add(dbOp);
                                 }
                             }
-                        }
 
+                            if (primaryKeyType != null)
+                            {
+                                // Replace Delete/Insert pairs with identical primary keys with an Update.
+                                //
+                                // !!TODO!!: Currently this code interprets Insert/Delete or Delete/Insert pairs as Updates.
+                                // Note that if a user inserts and then deletes a row with the same primary key in a
+                                // spacetimedb module, this is interpreted as an Update, while effectively it is a NoOp.
+                                for (var i = 0; i < insertOps.Count; i++)
+                                {
+                                    var insertOp = insertOps[i];
+                                    if (deleteOps.TryGetValue(insertOp.primaryKeyValue, out var deleteOp))
+                                    {
+                                        // We found an insert with a matching delete.
+                                        // Replace it with an update operation.
+                                        insertOps[i] = new DbOp
+                                        {
+                                            insertedPk = insertOp.insertedPk,
+                                            deletedPk = deleteOp.deletedPk,
+                                            table = insertOp.table,
+                                            op = TableOp.Update
+                                        };
+                                        deleteOps.Remove(insertOp.primaryKeyValue);
+                                    }
+                                }
+                                dbOps.AddRange(insertOps);
+                                dbOps.AddRange(deleteOps.Values);
+                            }
+                        }
                         break;
                     case ClientApi.Message.TypeOneofCase.IdentityToken:
                         break;
                     case ClientApi.Message.TypeOneofCase.Event:
                         break;
-                }
-                
-                // Factor out any insert/deletes into updates
-                for (var x = 0; x < dbEvents.Count; x++)
-                {
-                    var insertEvent = dbEvents[x];
-                    if (insertEvent.op != TableOp.Insert)
-                    {
-                        continue;
-                    }
-
-                    for (var y = 0; y < dbEvents.Count; y++)
-                    {
-                        var deleteEvent = dbEvents[y];
-                        if (deleteEvent.op != TableOp.Delete || deleteEvent.table != insertEvent.table
-                            || !insertEvent.table.ComparePrimaryKey(insertEvent.insertedPk, deleteEvent.deletedPk))
-                        {
-                            continue;
-                        }
-
-                        var updateEvent = new DbEvent
-                        {
-                            deletedPk = deleteEvent.deletedPk,
-                            insertedPk = insertEvent.insertedPk,
-                            op = TableOp.Update,
-                            table = insertEvent.table,
-                        };
-                        dbEvents[x] = updateEvent;
-                        dbEvents.RemoveAt(y);
-                        break;
-                    }
                 }
 
                 if (message.TypeCase == Message.TypeOneofCase.SubscriptionUpdate)
@@ -394,35 +368,32 @@ namespace SpacetimeDB
                                                 .Where(a => a.Op == TableRowOperation.Types.OperationType.Insert)
                                                 .Select(b => b.RowPk.ToByteArray());
                         var existingPks = clientTable.entries.Select(a => a.Key);
-                        dbEvents.AddRange(existingPks.Except(newPks, new ClientCache.TableCache.ByteArrayComparer())
-                                                     .Select(a => new DbEvent
-                                                     {
-                                                         deletedPk = a,
-                                                         newValue = null,
-                                                         oldValue = clientTable.entries[a].Item2,
-                                                         op = TableOp.Delete,
-                                                         table = clientTable,
-                                                     }));
+                        dbOps.AddRange(existingPks.Except(newPks, new ClientCache.TableCache.ByteArrayComparer())
+                        .Select(a => new DbOp
+                        {
+                            deletedPk = a,
+                            newValue = null,
+                            oldValue = clientTable.entries[a].Item2,
+                            op = TableOp.Delete,
+                            table = clientTable,
+                        }));
                     }
                 }
 
-
-                if (message.TypeCase == Message.TypeOneofCase.TransactionUpdate && 
+                if (message.TypeCase == Message.TypeOneofCase.TransactionUpdate &&
                     deserializeEventCache.TryGetValue(message.TransactionUpdate.Event.FunctionCall.Reducer, out var deserializer))
                 {
                     deserializer.Invoke(message.TransactionUpdate.Event);
                 }
 
-                return (message, dbEvents);
+                return (message, dbOps);
             }
         }
 
         public void Close()
         {
-            isClosing = true;
             connectionClosed = true;
             webSocket.Close();
-            _cancellationTokenSource.Cancel();            
             webSocket = null;
         }
 
@@ -434,8 +405,6 @@ namespace SpacetimeDB
         /// <param name="sslEnabled">Should websocket use SSL</param>
         public void Connect(string token, string host, string addressOrName, bool sslEnabled = true)
         {
-            isClosing = false;
-
             logger.Log($"SpacetimeDBClient: Connecting to {host} {addressOrName}");
             Task.Run(async () =>
             {
@@ -456,22 +425,22 @@ namespace SpacetimeDB
             });
         }
 
-        private void OnMessageProcessComplete(Message message, IList<DbEvent> events)
+        private void OnMessageProcessComplete(Message message, IList<DbOp> dbOps)
         {
             switch (message.TypeCase)
             {
                 case Message.TypeOneofCase.SubscriptionUpdate:
                 case Message.TypeOneofCase.TransactionUpdate:
                     // First trigger OnBeforeDelete
-                    for (var i = 0; i < events.Count; i++)
+                    for (var i = 0; i < dbOps.Count; i++)
                     {
                         // TODO: Reimplement updates when we add support for primary keys
-                        var ev = events[i];
-                        if (ev.op == TableOp.Delete && ev.table.TryGetValue(ev.deletedPk, out var oldVal))
+                        var update = dbOps[i];
+                        if (update.op == TableOp.Delete && update.table.TryGetValue(update.deletedPk, out var oldVal))
                         {
                             try
                             {
-                                ev.table.BeforeDeleteCallback?.Invoke(oldVal, message.TransactionUpdate?.Event);
+                                update.table.BeforeDeleteCallback?.Invoke(oldVal, message.TransactionUpdate?.Event);
                             }
                             catch (Exception e)
                             {
@@ -481,48 +450,48 @@ namespace SpacetimeDB
                     }
 
                     // Apply all of the state
-                    for (var i = 0; i < events.Count; i++)
+                    for (var i = 0; i < dbOps.Count; i++)
                     {
                         // TODO: Reimplement updates when we add support for primary keys
-                        var ev = events[i];
-                        switch (ev.op)
+                        var update = dbOps[i];
+                        switch (update.op)
                         {
                             case TableOp.Delete:
-                                ev.oldValue = events[i].table.DeleteEntry(ev.deletedPk);
-                                if (ev.oldValue != null)
+                                update.oldValue = dbOps[i].table.DeleteEntry(update.deletedPk);
+                                if (update.oldValue != null)
                                 {
-                                    ev.table.InternalValueDeletedCallback(ev.oldValue);
+                                    update.table.InternalValueDeletedCallback(update.oldValue);
                                 }
-                                events[i] = ev;
+                                dbOps[i] = update;
                                 break;
                             case TableOp.Insert:
-                                ev.newValue = events[i].table.InsertEntry(ev.insertedPk);
-                                ev.table.InternalValueInsertedCallback(ev.newValue);
-                                events[i] = ev;
+                                update.newValue = dbOps[i].table.InsertEntry(update.insertedPk);
+                                update.table.InternalValueInsertedCallback(update.newValue);
+                                dbOps[i] = update;
                                 break;
                             case TableOp.Update:
-                                ev.oldValue = events[i].table.DeleteEntry(ev.deletedPk);
-                                ev.newValue = events[i].table.InsertEntry(ev.insertedPk);
-                                if (ev.oldValue != null)
+                                update.oldValue = dbOps[i].table.DeleteEntry(update.deletedPk);
+                                update.newValue = dbOps[i].table.InsertEntry(update.insertedPk);
+                                if (update.oldValue != null)
                                 {
-                                    ev.table.InternalValueDeletedCallback(ev.oldValue);
+                                    update.table.InternalValueDeletedCallback(update.oldValue);
                                 }
-                                ev.table.InternalValueInsertedCallback(ev.newValue);
-                                events[i] = ev;
+                                update.table.InternalValueInsertedCallback(update.newValue);
+                                dbOps[i] = update;
                                 break;
                             default:
                                 throw new ArgumentOutOfRangeException();
                         }
                     }
-                    
+
                     // Send out events
-                    var eventCount = events.Count;
-                    for (var i = 0; i < eventCount; i++)
+                    var updateCount = dbOps.Count;
+                    for (var i = 0; i < updateCount; i++)
                     {
-                        var tableName = events[i].table.ClientTableType.Name;
-                        var tableOp = events[i].op;
-                        var oldValue = events[i].oldValue;
-                        var newValue = events[i].newValue;
+                        var tableName = dbOps[i].table.ClientTableType.Name;
+                        var tableOp = dbOps[i].op;
+                        var oldValue = dbOps[i].oldValue;
+                        var newValue = dbOps[i].newValue;
 
                         switch (tableOp)
                         {
@@ -531,21 +500,21 @@ namespace SpacetimeDB
                                 {
                                     try
                                     {
-                                        if (events[i].table.InsertCallback != null)
+                                        if (dbOps[i].table.InsertCallback != null)
                                         {
-                                            events[i].table.InsertCallback.Invoke(newValue, message.TransactionUpdate?.Event);
+                                            dbOps[i].table.InsertCallback.Invoke(newValue, message.TransactionUpdate?.Event);
                                         }
                                     }
                                     catch (Exception e)
                                     {
                                         logger.LogException(e);
                                     }
-                                    
+
                                     try
                                     {
-                                        if (events[i].table.RowUpdatedCallback != null)
+                                        if (dbOps[i].table.RowUpdatedCallback != null)
                                         {
-                                            events[i].table.RowUpdatedCallback
+                                            dbOps[i].table.RowUpdatedCallback
                                                 .Invoke(tableOp, null, newValue, message.TransactionUpdate?.Event);
                                         }
                                     }
@@ -565,11 +534,11 @@ namespace SpacetimeDB
                                 {
                                     if (oldValue != null && newValue == null)
                                     {
-                                        if (events[i].table.DeleteCallback != null)
+                                        if (dbOps[i].table.DeleteCallback != null)
                                         {
                                             try
                                             {
-                                                events[i].table.DeleteCallback.Invoke(oldValue, message.TransactionUpdate?.Event);
+                                                dbOps[i].table.DeleteCallback.Invoke(oldValue, message.TransactionUpdate?.Event);
                                             }
                                             catch (Exception e)
                                             {
@@ -577,12 +546,12 @@ namespace SpacetimeDB
                                             }
                                         }
 
-                                        if (events[i].table.RowUpdatedCallback != null)
+                                        if (dbOps[i].table.RowUpdatedCallback != null)
                                         {
                                             try
                                             {
-                                                events[i].table.RowUpdatedCallback
-                                                     .Invoke(tableOp, oldValue, null, message.TransactionUpdate?.Event);
+                                                dbOps[i].table.RowUpdatedCallback
+                                                    .Invoke(tableOp, oldValue, null, message.TransactionUpdate?.Event);
                                             }
                                             catch (Exception e)
                                             {
@@ -603,22 +572,22 @@ namespace SpacetimeDB
                                     {
                                         try
                                         {
-                                            if (events[i].table.UpdateCallback != null)
+                                            if (dbOps[i].table.UpdateCallback != null)
                                             {
-                                                events[i].table.UpdateCallback.Invoke(oldValue, newValue, message.TransactionUpdate?.Event);
+                                                dbOps[i].table.UpdateCallback.Invoke(oldValue, newValue, message.TransactionUpdate?.Event);
                                             }
                                         }
                                         catch (Exception e)
                                         {
                                             logger.LogException(e);
                                         }
-                                        
+
                                         try
                                         {
-                                            if (events[i].table.RowUpdatedCallback != null)
+                                            if (dbOps[i].table.RowUpdatedCallback != null)
                                             {
-                                                events[i].table.RowUpdatedCallback
-                                                         .Invoke(tableOp, oldValue, null, message.TransactionUpdate?.Event);
+                                                dbOps[i].table.RowUpdatedCallback
+                                                        .Invoke(tableOp, oldValue, null, message.TransactionUpdate?.Event);
                                             }
                                         }
                                         catch (Exception e)
@@ -681,17 +650,20 @@ namespace SpacetimeDB
 
         public void InternalCallReducer(string json)
         {
-            if(!webSocket.IsConnected)
+            if (!webSocket.IsConnected)
             {
                 logger.LogError("Cannot call reducer, not connected to server!");
                 return;
             }
-            webSocket.Send(Encoding.ASCII.GetBytes("{ \"call\": " + json + " }"));
+
+            var textMessage = "{ \"call\": " + json + " }";
+            var message = Encoding.ASCII.GetBytes(textMessage);
+            webSocket.Send(message);
         }
 
         public void Subscribe(List<string> queries)
         {
-            if(!webSocket.IsConnected)
+            if (!webSocket.IsConnected)
             {
                 logger.LogError("Cannot subscribe, not connected to server!");
                 return;
@@ -706,7 +678,7 @@ namespace SpacetimeDB
 
             while (_nextMessageQueue.TryTake(out var nextMessage))
             {
-                OnMessageProcessComplete(nextMessage.message, nextMessage.events);
+                OnMessageProcessComplete(nextMessage.message, nextMessage.dbOps);
             }
         }
     }


### PR DESCRIPTION
Use a hashmap to lookup if the primary key of an insert operations matches the primary key of delete operation. This is more performant then the nested loop.

Additionally rename DbEvent to DbOp for consistency with other SDKs, and more appropriate naming.

This change depends on a change in SpacetimeDB generate to add functions to get the primary key value for a table row
https://github.com/clockworklabs/SpacetimeDB/pull/118