### PR TITLE
Switch to variadic params for Subscribe queries

### DIFF
--- a/examples/quickstart/client/Program.cs
+++ b/examples/quickstart/client/Program.cs
@@ -113,7 +113,7 @@ void Reducer_OnSendMessageEvent(ReducerEvent reducerEvent, string text)
 
 void OnConnect()
 {
-    SpacetimeDBClient.instance.Subscribe(new List<string> { "SELECT * FROM User", "SELECT * FROM Message" });
+    SpacetimeDBClient.instance.Subscribe("SELECT * FROM User", "SELECT * FROM Message");
 }
 
 void OnIdentityReceived(string authToken, Identity identity, Address _address)

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -624,7 +624,7 @@ namespace SpacetimeDB
             });
         }
 
-        public void Subscribe(List<string> queries)
+        public void Subscribe(params string[] queries)
         {
             if (!webSocket.IsConnected)
             {


### PR DESCRIPTION
## Description of Changes

Accept variadic params or array of queries instead of a `List<string>`.

This is a breaking change, but it should be a slight improvement for the majority of cases with statically defined queries.

## API

 - [x] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*
