### PR TITLE
Don't use BuiltinType.I/U128, use AlgebraicType.I/U128

### DIFF
--- a/src/Primitives.cs
+++ b/src/Primitives.cs
@@ -39,7 +39,7 @@ namespace SpacetimeDB
             }
 
             public AlgebraicType GetAlgebraicType(ITypeRegistrar registrar) =>
-                new AlgebraicType.Builtin(new BuiltinType.I128(new Unit()));
+                new AlgebraicType.I128(new Unit());
         }
     }
 
@@ -76,7 +76,7 @@ namespace SpacetimeDB
             }
 
             public AlgebraicType GetAlgebraicType(ITypeRegistrar registrar) =>
-                new AlgebraicType.Builtin(new BuiltinType.U128(new Unit()));
+                new AlgebraicType.U128(new Unit());
         }
     }
 


### PR DESCRIPTION
## Description of Changes

Required to make "SDK Tests" pass in https://github.com/clockworklabs/SpacetimeDB/pull/1559.

## API

Not breaking.

## Requires SpacetimeDB PRs

- https://github.com/clockworklabs/SpacetimeDB/pull/1559