### PR TITLE
Restore `dotnet pack` functionality

### DIFF
--- a/SpacetimeDB.ClientSDK.csproj
+++ b/SpacetimeDB.ClientSDK.csproj
@@ -9,7 +9,6 @@
     <Title>SpacetimeDB SDK</Title>
     <Authors>jdetter</Authors>
     <Company>Clockwork Labs</Company>
-    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <Product>SpacetimeDB</Product>
     <Description>The SpacetimeDB SDK is a software development kit (SDK) designed to simplify the interaction with SpacetimeDB server modules.</Description>
     <Copyright>2024</Copyright>
@@ -31,7 +30,6 @@
   <ItemGroup>
     <None Update="logo.png" Pack="true" PackagePath="" />
     <None Update="README.md" Pack="true" PackagePath="" />
-    <None Include="LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
   </ItemGroup>
 
 </Project>

--- a/SpacetimeDB.ClientSDK.csproj
+++ b/SpacetimeDB.ClientSDK.csproj
@@ -5,11 +5,11 @@
     <LangVersion>9</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>SpacetimeDB.ClientSDK</PackageId>
     <Title>SpacetimeDB SDK</Title>
     <Authors>jdetter</Authors>
     <Company>Clockwork Labs</Company>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <Product>SpacetimeDB</Product>
     <Description>The SpacetimeDB SDK is a software development kit (SDK) designed to simplify the interaction with SpacetimeDB server modules.</Description>
     <Copyright>2024</Copyright>
@@ -31,6 +31,7 @@
   <ItemGroup>
     <None Update="logo.png" Pack="true" PackagePath="" />
     <None Update="README.md" Pack="true" PackagePath="" />
+    <None Include="LICENSE.txt" Pack="true" PackagePath="LICENSE.txt" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description of Changes
Single-line change so that `dotnet pack` stops complaining that nothing was generated.

Per @RReverser this brings this package more in line with our other C# packages.

## API
Nah nothing breaking.

## Requires SpacetimeDB PRs
Nope