### PR TITLE
Bump version to 0.12.0

### DIFF
--- a/SpacetimeDB.ClientSDK.csproj
+++ b/SpacetimeDB.ClientSDK.csproj
@@ -16,13 +16,13 @@
     <PackageIcon>logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/clockworklabs/spacetimedb-csharp-sdk</RepositoryUrl>
-    <AssemblyVersion>0.11.0</AssemblyVersion>
+    <AssemblyVersion>0.12.0</AssemblyVersion>
     <Version>$(AssemblyVersion)</Version>
     <DefaultItemExcludes>$(DefaultItemExcludes);examples/**;tests/**</DefaultItemExcludes>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.BSATN.Runtime" Version="0.11.*" />
+    <PackageReference Include="SpacetimeDB.BSATN.Runtime" Version="0.12.*" />
 
     <InternalsVisibleTo Include="SpacetimeDB.Tests" />
   </ItemGroup>


### PR DESCRIPTION
## Description of Changes
We have merged https://github.com/clockworklabs/spacetimedb-csharp-sdk/pull/116 which relies on version 0.12.0 of packages in the SpacetimeDB repo.

## API

No; it's more that this tracks an already-merged breaking change.


## Requires SpacetimeDB PRs
https://github.com/clockworklabs/SpacetimeDB/pull/1578