### PR TITLE
Copy files from old repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ This repository contains the [Unity](https://unity.com/) SDK for SpacetimeDB. Th
 
 ## Documentation
 
-The Unity SDK uses the same code as the C# SDK. You can find the documentation for the C# SDK in the [C# SDK Reference](README.dotnet.md).
+The Unity SDK uses the same code as the C# SDK. You can find the documentation for the C# SDK in the [C# SDK Reference](https://spacetimedb.com/docs/sdks/c-sharp)
 
 There is also a comprehensive Unity tutorial/demo available:
-
 - [Unity Tutorial](https://spacetimedb.com/docs/unity/part-1) Doc
 - [Unity Demo](https://github.com/clockworklabs/SpacetimeDBUnityTutorial) Repo
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.clockworklabs.spacetimedbsdk",
   "displayName": "SpacetimeDB SDK",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "The SpacetimeDB Client SDK is a software development kit (SDK) designed to interact with and manipulate SpacetimeDB modules..",
   "keywords": [],
   "author": {


### PR DESCRIPTION
## Description of Changes
For some reason, this repo was not quite properly synced up with the state of https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk-archive after https://github.com/clockworklabs/spacetimedb-csharp-sdk/pull/117.

It's unclear to me how this happened, since the current state seems to be compatible with 0.11, but the [0.11 release commit/PR](https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk-archive/commit/382cce05fecbc00caf7c7d060fbde9a2854ad981) also bumped the `package.json` version, which didn't happen in this repo.

I re-copied files over. Fortunately, the only real changes were to `package.json` and `README.md`.

## API
No breaking changes.

## Requires SpacetimeDB PRs
None