### PR TITLE
Call reducer events on failed updates

### DIFF
--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -352,6 +352,15 @@ namespace SpacetimeDB
                                 }
                                 break;
                             case UpdateStatus.Failed(var failed):
+                                // Convert the generic event arguments in to a domain specific event object
+                                try
+                                {
+                                    reducerEvent = ReducerEventFromDbEvent(transactionUpdate);
+                                }
+                                catch (Exception e)
+                                {
+                                    Logger.LogException(e);
+                                }
                                 break;
                             case UpdateStatus.OutOfEnergy(var outOfEnergy):
                                 Logger.LogWarning("Failed to execute reducer: out of energy.");


### PR DESCRIPTION
## Description of Changes
Apply Alessandro's bugfix to call reducer events on failed updates.

I couldn't directly open a PR for Alessandro's branch because it's based on v0.11.0-beta, which is an orphan commit.

This is the original commit:
```
commit efbb0ccc7633276876801c719e9f8e91f7ac9e51 (origin/alessandro/bugfix/v0.11.0-beta-bugfix)
Author: Alessandro Asoni <alessandro@clockworklabs.io>
Date:   Fri Sep 6 15:49:50 2024 +0200

    Call reducer event for failed updates

diff --git a/Scripts/SpacetimeDBClient.cs b/Scripts/SpacetimeDBClient.cs
index 89774b5..dd7193c 100644
--- a/Scripts/SpacetimeDBClient.cs
+++ b/Scripts/SpacetimeDBClient.cs
@@ -352,6 +352,15 @@ namespace SpacetimeDB
                                 }
                                 break;
                             case UpdateStatus.Failed(var failed):
+                                // Convert the generic event arguments in to a domain specific event object
+                                try
+                                {
+                                    reducerEvent = ReducerEventFromDbEvent(transactionUpdate);
+                                }
+                                catch (Exception e)
+                                {
+                                    Logger.LogException(e);
+                                }
                                 break;
                             case UpdateStatus.OutOfEnergy(var outOfEnergy):
                                 Logger.LogWarning("Failed to execute reducer: out of energy.");
```

## API
No

## Requires SpacetimeDB PRs
None