### PR TITLE
Merge table cache into table handle

### DIFF
--- a/src/ClientCache.cs
+++ b/src/ClientCache.cs
@@ -6,74 +6,22 @@ using SpacetimeDB.Internal;
 
 namespace SpacetimeDB
 {
+    // TODO: merge this into `RemoteTables`.
+    // It should just provide auto-generated `GetTable` and `GetTables` methods.
     public class ClientCache
     {
-        public interface ITableCache : IEnumerable<KeyValuePair<byte[], IDatabaseRow>>
-        {
-            Type ClientTableType { get; }
-            bool InsertEntry(byte[] rowBytes, IDatabaseRow value);
-            bool DeleteEntry(byte[] rowBytes);
-            IDatabaseRow DecodeValue(byte[] bytes);
-            IRemoteTableHandle Handle { get; }
-        }
+        private readonly Dictionary<string, IRemoteTableHandle> tables = new();
 
-        public class TableCache<Row> : ITableCache
+        public void AddTable<Row>(string name, IRemoteTableHandle table)
             where Row : IDatabaseRow, new()
         {
-            public TableCache(IRemoteTableHandle handle) => Handle = handle;
-
-            public IRemoteTableHandle Handle { get; init; }
-
-            public Type ClientTableType => typeof(Row);
-
-            public readonly Dictionary<byte[], Row> Entries = new(ByteArrayComparer.Instance);
-
-            /// <summary>
-            /// Inserts the value into the table. There can be no existing value with the provided BSATN bytes.
-            /// </summary>
-            /// <param name="rowBytes">The BSATN encoded bytes of the row to retrieve.</param>
-            /// <param name="value">The parsed row encoded by the <paramref>rowBytes</paramref>.</param>
-            /// <returns>True if the row was inserted, false if the row wasn't inserted because it was a duplicate.</returns>
-            public bool InsertEntry(byte[] rowBytes, IDatabaseRow value) => Entries.TryAdd(rowBytes, (Row)value);
-
-            /// <summary>
-            /// Deletes a value from the table.
-            /// </summary>
-            /// <param name="rowBytes">The BSATN encoded bytes of the row to remove.</param>
-            /// <returns>True if and only if the value was previously resident and has been deleted.</returns>
-            public bool DeleteEntry(byte[] rowBytes)
-            {
-                if (Entries.Remove(rowBytes))
-                {
-                    return true;
-                }
-
-                Log.Warn("Deleting value that we don't have (no cached value available)");
-                return false;
-            }
-
-            // The function to use for decoding a type value.
-            public IDatabaseRow DecodeValue(byte[] bytes) => BSATNHelpers.Decode<Row>(bytes);
-
-            public IEnumerator<KeyValuePair<byte[], IDatabaseRow>> GetEnumerator() => Entries.Select(kv => new KeyValuePair<byte[], IDatabaseRow>(kv.Key, kv.Value)).GetEnumerator();
-
-            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-        }
-
-        private readonly Dictionary<string, ITableCache> tables = new();
-
-        public void AddTable<Row>(string name, IRemoteTableHandle handle)
-            where Row : IDatabaseRow, new()
-        {
-            var cache = new TableCache<Row>(handle);
-            handle.SetCache(cache);
-            if (!tables.TryAdd(name, cache))
+            if (!tables.TryAdd(name, table))
             {
                 Log.Error($"Table with name already exists: {name}");
             }
         }
 
-        public ITableCache? GetTable(string name)
+        public IRemoteTableHandle? GetTable(string name)
         {
             if (tables.TryGetValue(name, out var table))
             {
@@ -84,6 +32,6 @@ namespace SpacetimeDB
             return null;
         }
 
-        public IEnumerable<ITableCache> GetTables() => tables.Values;
+        public IEnumerable<IRemoteTableHandle> GetTables() => tables.Values;
     }
 }


### PR DESCRIPTION
## Description of Changes

Merges cache into the table handle as suggested on the original PR + hides most table methods that shouldn't be part of the stable API.

Few remaining methods will need a codegen change to be available only to subclasses, so for now that's out of scope.

Same for merging ClientCache into RemoteTables - we shouldn't need a separate collection, and instead could autogenerate a switch expression over table name.

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*
