### PR TITLE
Hide more APIs

### DIFF
--- a/examples~/quickstart/client/Program.cs
+++ b/examples~/quickstart/client/Program.cs
@@ -39,7 +39,9 @@ void Main()
     conn.RemoteReducers.OnSetName += Reducer_OnSetNameEvent;
     conn.RemoteReducers.OnSendMessage += Reducer_OnSendMessageEvent;
 
+#pragma warning disable CS0612 // Using obsolete API
     conn.onUnhandledReducerError += onUnhandledReducerError;
+#pragma warning restore CS0612 // Using obsolete API
 
     // declare a threadsafe cancel token to cancel the process loop
     var cancellationTokenSource = new CancellationTokenSource();

--- a/examples~/quickstart/client/Program.cs
+++ b/examples~/quickstart/client/Program.cs
@@ -178,7 +178,7 @@ void ProcessThread(DbConnection conn, CancellationToken ct)
         // loop until cancellation token
         while (!ct.IsCancellationRequested)
         {
-            conn.Update();
+            conn.FrameTick();
 
             ProcessCommands(conn.RemoteReducers);
 

--- a/examples~/quickstart/client/Program.cs
+++ b/examples~/quickstart/client/Program.cs
@@ -189,7 +189,7 @@ void ProcessThread(DbConnection conn, CancellationToken ct)
     }
     finally
     {
-        conn.Close();
+        conn.Disconnect();
     }
 }
 

--- a/src/ClientCache.cs
+++ b/src/ClientCache.cs
@@ -21,7 +21,7 @@ namespace SpacetimeDB
             }
         }
 
-        public IRemoteTableHandle? GetTable(string name)
+        internal IRemoteTableHandle? GetTable(string name)
         {
             if (tables.TryGetValue(name, out var table))
             {
@@ -32,6 +32,6 @@ namespace SpacetimeDB
             return null;
         }
 
-        public IEnumerable<IRemoteTableHandle> GetTables() => tables.Values;
+        internal IEnumerable<IRemoteTableHandle> GetTables() => tables.Values;
     }
 }

--- a/src/ConsoleLogger.cs
+++ b/src/ConsoleLogger.cs
@@ -2,7 +2,7 @@
 
 namespace SpacetimeDB
 {
-    public class ConsoleLogger : ISpacetimeDBLogger
+    internal class ConsoleLogger : ISpacetimeDBLogger
     {
         [Flags]
         public enum LogLevel

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -111,27 +111,19 @@ namespace SpacetimeDB
         /// <summary>
         /// Called when an exception occurs when sending a message.
         /// </summary>
+        [Obsolete]
         public event Action<Exception>? onSendError;
 
         private readonly Dictionary<uint, ISubscriptionHandle> subscriptions = new();
 
         /// <summary>
-        /// Invoked when a subscription is about to start being processed. This is called even before OnBeforeDelete.
-        /// </summary>
-        public event Action? onBeforeSubscriptionApplied;
-
-        /// <summary>
         /// Invoked when a reducer is returned with an error and has no client-side handler.
         /// </summary>
+        [Obsolete]
         public event Action<ReducerEvent<Reducer>>? onUnhandledReducerError;
 
-        /// <summary>
-        /// Invoked when an event message is received or at the end of a transaction update.
-        /// </summary>
-        public event Action<ServerMessage>? onEvent;
-
-        public readonly Address clientAddress = Address.Random();
-        public Identity? clientIdentity { get; private set; }
+        public readonly Address Address = Address.Random();
+        public Identity? Identity { get; private set; }
 
         internal WebSocket webSocket;
         private bool connectionClosed;
@@ -499,7 +491,7 @@ namespace SpacetimeDB
             {
                 try
                 {
-                    await webSocket.Connect(token, uri, addressOrName, clientAddress);
+                    await webSocket.Connect(token, uri, addressOrName, Address);
                 }
                 catch (Exception e)
                 {
@@ -605,7 +597,6 @@ namespace SpacetimeDB
             {
                 case ServerMessage.InitialSubscription(var initialSubscription):
                     {
-                        onBeforeSubscriptionApplied?.Invoke();
                         stats.ParseMessageTracker.InsertRequest(timestamp, $"type={nameof(ServerMessage.InitialSubscription)}");
                         stats.SubscriptionRequestTracker.FinishTrackingRequest(initialSubscription.RequestId);
                         var eventContext = ToEventContext(new Event<Reducer>.SubscribeApplied());
@@ -630,7 +621,7 @@ namespace SpacetimeDB
                         var hostDuration = TimeSpan.FromMilliseconds(transactionUpdate.HostExecutionDurationMicros / 1000.0d);
                         stats.AllReducersTracker.InsertRequest(hostDuration, $"reducer={reducer}");
                         var callerIdentity = transactionUpdate.CallerIdentity;
-                        if (callerIdentity == clientIdentity)
+                        if (callerIdentity == Identity)
                         {
                             // This was a request that we initiated
                             var requestId = transactionUpdate.ReducerCall.RequestId;
@@ -648,14 +639,6 @@ namespace SpacetimeDB
 
                         var eventContext = ToEventContext(new Event<Reducer>.Reducer(reducerEvent));
                         OnMessageProcessCompleteUpdate(eventContext, dbOps);
-                        try
-                        {
-                            onEvent?.Invoke(message);
-                        }
-                        catch (Exception e)
-                        {
-                            Log.Exception(e);
-                        }
 
                         var reducerFound = false;
                         try
@@ -683,7 +666,7 @@ namespace SpacetimeDB
                 case ServerMessage.IdentityToken(var identityToken):
                     try
                     {
-                        clientIdentity = identityToken.Identity;
+                        Identity = identityToken.Identity;
                         onConnect?.Invoke(identityToken.Identity, identityToken.Token);
                     }
                     catch (Exception e)
@@ -693,14 +676,7 @@ namespace SpacetimeDB
                     break;
 
                 case ServerMessage.OneOffQueryResponse:
-                    try
-                    {
-                        onEvent?.Invoke(message);
-                    }
-                    catch (Exception e)
-                    {
-                        Log.Exception(e);
-                    }
+                    /* OneOffQuery is async and handles its own responses */
                     break;
 
                 default:
@@ -807,9 +783,9 @@ namespace SpacetimeDB
             return resultTable.Rows.Select(BSATNHelpers.Decode<T>).ToArray();
         }
 
-        public bool IsConnected() => webSocket.IsConnected;
+        public bool IsActive => webSocket.IsConnected;
 
-        public void Update()
+        public void FrameTick()
         {
             webSocket.Update();
             while (_preProcessedNetworkMessages.TryTake(out var preProcessedMessage))

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -462,7 +462,7 @@ namespace SpacetimeDB
             return processed;
         }
 
-        public void Close()
+        public void Disconnect()
         {
             isClosing = true;
             connectionClosed = true;
@@ -475,7 +475,7 @@ namespace SpacetimeDB
         /// </summary>
         /// <param name="uri"> URI of the SpacetimeDB server (ex: https://testnet.spacetimedb.com)
         /// <param name="addressOrName">The name or address of the database to connect to</param>
-        public void Connect(string? token, string uri, string addressOrName)
+        internal void Connect(string? token, string uri, string addressOrName)
         {
             isClosing = false;
 

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -140,7 +140,7 @@ namespace SpacetimeDB
 
         protected DbConnectionBase()
         {
-            var options = new ConnectOptions
+            var options = new WebSocket.ConnectOptions
             {
                 //v1.bin.spacetimedb
                 //v1.text.spacetimedb

--- a/src/UnityDebugLogger.cs
+++ b/src/UnityDebugLogger.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace SpacetimeDB
 {
-    public class UnityDebugLogger : ISpacetimeDBLogger
+    internal class UnityDebugLogger : ISpacetimeDBLogger
     {
         public void Debug(string message)
         {

--- a/src/WebSocket.cs
+++ b/src/WebSocket.cs
@@ -11,23 +11,22 @@ using System.Threading.Tasks;
 
 namespace SpacetimeDB
 {
-    public delegate void WebSocketOpenEventHandler();
-
-    public delegate void WebSocketMessageEventHandler(byte[] message, DateTime timestamp);
-
-    public delegate void WebSocketCloseEventHandler(WebSocketCloseStatus? code, WebSocketError? error);
-
-    public delegate void WebSocketConnectErrorEventHandler(WebSocketError? error, string message);
-    public delegate void WebSocketSendErrorEventHandler(Exception e);
-
-    public struct ConnectOptions
+    internal class WebSocket
     {
-        public string Protocol;
-    }
+        public delegate void OpenEventHandler();
 
+        public delegate void MessageEventHandler(byte[] message, DateTime timestamp);
 
-    public class WebSocket
-    {
+        public delegate void CloseEventHandler(WebSocketCloseStatus? code, WebSocketError? error);
+
+        public delegate void ConnectErrorEventHandler(WebSocketError? error, string message);
+        public delegate void SendErrorEventHandler(Exception e);
+
+        public struct ConnectOptions
+        {
+            public string Protocol;
+        }
+
         // WebSocket buffer for incoming messages
         private static readonly int MAXMessageSize = 0x4000000; // 64MB
 
@@ -43,11 +42,11 @@ namespace SpacetimeDB
             _options = options;
         }
 
-        public event WebSocketOpenEventHandler? OnConnect;
-        public event WebSocketConnectErrorEventHandler? OnConnectError;
-        public event WebSocketSendErrorEventHandler? OnSendError;
-        public event WebSocketMessageEventHandler? OnMessage;
-        public event WebSocketCloseEventHandler? OnClose;
+        public event OpenEventHandler? OnConnect;
+        public event ConnectErrorEventHandler? OnConnectError;
+        public event SendErrorEventHandler? OnSendError;
+        public event MessageEventHandler? OnMessage;
+        public event CloseEventHandler? OnClose;
 
         public bool IsConnected { get { return Ws != null && Ws.State == WebSocketState.Open; } }
 

--- a/tests~/SnapshotTests.VerifyAllTablesParsed.verified.txt
+++ b/tests~/SnapshotTests.VerifyAllTablesParsed.verified.txt
@@ -1,6 +1,10 @@
 ﻿{
   Events: {
-    OnIdentityReceived: Identity_1,
+    Log: SpacetimeDBClient: Connecting to wss://spacetimedb.com example,
+    OnConnect: {
+      identity: Identity_1,
+      token: eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJoZXhfaWRlbnRpdHkiOiI4ZjkwY2M5NGE5OTY4ZGY2ZDI5N2JhYTY2NTAzYTg5M2IxYzM0YjBiMDAyNjhhNTE0ODk4ZGQ5NTRiMGRhMjBiIiwiaWF0IjoxNzE4NDg3NjY4LCJleHAiOm51bGx9.PSn481bLRqtFwIh46nOXDY14X3GKbz8t4K4GmBmz50loU6xzeL7zDdCh1V2cmiQsoGq8Erxg0r_6b6Y5SqKoBA
+    },
     OnInsertUser: {
       eventContext: {
         Reducers: {Scrubbed},
@@ -33,18 +37,6 @@
         online: true
       }
     },
-    OnEvent: {
-      status: {Scrubbed},
-      timestamp: 1718487763059031,
-      caller_identity: Identity_2,
-      caller_address: Guid_1,
-      reducer_call: {
-        reducer_name: __identity_connected__,
-        args: 
-      },
-      energy_quanta_used: 1957615,
-      host_execution_duration_micros: 66
-    },
     OnUpdateUser: {
       eventContext: {
         Reducers: {Scrubbed},
@@ -73,19 +65,6 @@
         name: A,
         online: true
       }
-    },
-    OnEvent: {
-      status: {Scrubbed},
-      timestamp: 1718487768057579,
-      caller_identity: Identity_1,
-      caller_address: Guid_2,
-      reducer_call: {
-        reducer_name: set_name,
-        args: AQAAAEE=,
-        request_id: 1
-      },
-      energy_quanta_used: 4345615,
-      host_execution_duration_micros: 70
     },
     OnSetName: {
       Reducers: {Scrubbed},
@@ -129,19 +108,6 @@
         sent: 1718487775346381,
         text: Hello, A!
       }
-    },
-    OnEvent: {
-      status: {Scrubbed},
-      timestamp: 1718487775346381,
-      caller_identity: Identity_2,
-      caller_address: Guid_1,
-      reducer_call: {
-        reducer_name: send_message,
-        args: CQAAAEhlbGxvLCBBIQ==,
-        request_id: 1
-      },
-      energy_quanta_used: 2779615,
-      host_execution_duration_micros: 57
     },
     OnSendMessage: {
       Reducers: {Scrubbed},
@@ -190,19 +156,6 @@
         online: true
       }
     },
-    OnEvent: {
-      status: {Scrubbed},
-      timestamp: 1718487777307855,
-      caller_identity: Identity_2,
-      caller_address: Guid_1,
-      reducer_call: {
-        reducer_name: set_name,
-        args: AQAAAEI=,
-        request_id: 2
-      },
-      energy_quanta_used: 4268615,
-      host_execution_duration_micros: 98
-    },
     OnSetName: {
       Reducers: {Scrubbed},
       Reducer: {
@@ -246,19 +199,6 @@
         text: Hello, B!
       }
     },
-    OnEvent: {
-      status: {Scrubbed},
-      timestamp: 1718487783175083,
-      caller_identity: Identity_1,
-      caller_address: Guid_2,
-      reducer_call: {
-        reducer_name: send_message,
-        args: CQAAAEhlbGxvLCBCIQ==,
-        request_id: 2
-      },
-      energy_quanta_used: 2677615,
-      host_execution_duration_micros: 40
-    },
     OnSendMessage: {
       Reducers: {Scrubbed},
       Reducer: {
@@ -301,19 +241,6 @@
         sent: 1718487787645364,
         text: Goodbye!
       }
-    },
-    OnEvent: {
-      status: {Scrubbed},
-      timestamp: 1718487787645364,
-      caller_identity: Identity_2,
-      caller_address: Guid_1,
-      reducer_call: {
-        reducer_name: send_message,
-        args: CAAAAEdvb2RieWUh,
-        request_id: 3
-      },
-      energy_quanta_used: 2636615,
-      host_execution_duration_micros: 28
     },
     OnSendMessage: {
       Reducers: {Scrubbed},
@@ -359,18 +286,6 @@
         online: false
       }
     },
-    OnEvent: {
-      status: {Scrubbed},
-      timestamp: 1718487791901504,
-      caller_identity: Identity_2,
-      caller_address: Guid_1,
-      reducer_call: {
-        reducer_name: __identity_disconnected__,
-        args: 
-      },
-      energy_quanta_used: 3595615,
-      host_execution_duration_micros: 75
-    },
     OnInsertMessage: {
       eventContext: {
         Reducers: {Scrubbed},
@@ -395,19 +310,6 @@
         sent: 1718487794937841,
         text: Goodbye!
       }
-    },
-    OnEvent: {
-      status: {Scrubbed},
-      timestamp: 1718487794937841,
-      caller_identity: Identity_1,
-      caller_address: Guid_2,
-      reducer_call: {
-        reducer_name: send_message,
-        args: CAAAAEdvb2RieWUh,
-        request_id: 3
-      },
-      energy_quanta_used: 2636615,
-      host_execution_duration_micros: 34
     },
     OnSendMessage: {
       Reducers: {Scrubbed},

--- a/tests~/tests.csproj
+++ b/tests~/tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="xunit" Version="2.8.1" />
     <ProjectReference Include="../SpacetimeDB.ClientSDK.csproj" />
 
-    <Compile Include="../examples~/quickstart/client/module_bindings/**/*.cs" />
+    <ProjectReference Include="../examples~/quickstart/client/client.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description of Changes

Removing unstable APIs that are not used by BitCraft; marking others with [Obsolete] and renaming few others to match the proposal.

One exception is InternalCallReducer - it would need some further changes to codegen; marking it as Obsolete right now would cause all generated clients to show noisy warnings.

## API

 - [x] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*
