### PR TITLE
Try to catch flaky bugs

### DIFF
--- a/tests~/SnapshotTests.cs
+++ b/tests~/SnapshotTests.cs
@@ -12,9 +12,20 @@ public class SnapshotTests
 {
     class Events : List<KeyValuePair<string, object?>>
     {
+        private bool frozen;
+
         public void Add(string name, object? value = null)
         {
+            if (frozen)
+            {
+                throw new InvalidOperationException("This is a bug. We have snapshotted the events and don't expect any more to arrive.");
+            }
             base.Add(new(name, value));
+        }
+
+        public void Freeze()
+        {
+            frozen = true;
         }
     }
 
@@ -344,6 +355,7 @@ public class SnapshotTests
         }
 
         // Verify dumped events and the final client state.
+        events.Freeze();
         await Verify(
                 new
                 {


### PR DESCRIPTION
## Description of Changes

We have some flaky bug where Events are getting modified while we're already iterating over them in the snapshot.

I think this might've been fixed by #144, but add extra checks just in case so that the exception is thrown in a concrete event that causes it, and not inside snapshot serialization.

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*
