### PR TITLE
Fix `gen-client-api` scripts for new CLI API

### DIFF
--- a/tools~/gen-client-api.bat
+++ b/tools~/gen-client-api.bat
@@ -10,8 +10,8 @@ cd %CL_HOME%\SpacetimeDB\crates\client-api-messages
 cargo run --example get_ws_schema > %CL_HOME%/schema.json
 
 cd %CL_HOME%\SpacetimeDB\crates\cli
-cargo run -- generate -l csharp -n SpacetimeDB.ClientApi ^
-  --json-module %CL_HOME%\schema.json ^
+cargo run -- generate -l csharp --namespace SpacetimeDB.ClientApi ^
+  --module-def %CL_HOME%\schema.json ^
   -o %CL_HOME%\spacetimedb-csharp-sdk\src\SpacetimeDB\ClientApi
 
 cd %CL_HOME%\spacetimedb-csharp-sdk\src\SpacetimeDB\ClientApi

--- a/tools~/gen-client-api.sh
+++ b/tools~/gen-client-api.sh
@@ -5,8 +5,8 @@ cd $CL_HOME/SpacetimeDB/crates/client-api-messages
 cargo run --example get_ws_schema > $CL_HOME/schema.json
 
 cd $CL_HOME/SpacetimeDB/crates/cli
-cargo run -- generate -l csharp -n SpacetimeDB.ClientApi \
-  --json-module $CL_HOME/schema.json \
+cargo run -- generate -l csharp --namespace SpacetimeDB.ClientApi \
+  --module-def $CL_HOME/schema.json \
   -o $CL_HOME/spacetimedb-csharp-sdk/src/SpacetimeDB/ClientApi
 
 cd $CL_HOME/spacetimedb-csharp-sdk/src/SpacetimeDB/ClientApi


### PR DESCRIPTION
## Description of Changes
The CLI arg changes in https://github.com/clockworklabs/SpacetimeDB/pull/1741 broke these scripts. This PR incorporates the param renames.

## API
No changes to how things are used.

## Requires SpacetimeDB PRs
I guess https://github.com/clockworklabs/SpacetimeDB/pull/1741