### PR TITLE
Fix Reconnection Logic

### DIFF
--- a/src/SpacetimeDBNetworkManager.cs
+++ b/src/SpacetimeDBNetworkManager.cs
@@ -10,19 +10,19 @@ namespace SpacetimeDB
 	// Attach this to a gameobject in your scene to use SpacetimeDB.
 	public class SpacetimeDBNetworkManager : MonoBehaviour
 	{
-		private static bool _alreadyInitialized;
+		private static SpacetimeDBNetworkManager _instance;
 
 		public void Awake()
 		{
 			// Ensure that users don't create several SpacetimeDBNetworkManager instances.
 			// We're using a global (static) list of active connections and we don't want several instances to walk over it several times.
-			if (_alreadyInitialized)
+			if (_instance != null)
 			{
 				throw new InvalidOperationException("SpacetimeDBNetworkManager is a singleton and should only be attached once.");
 			}
 			else
 			{
-				_alreadyInitialized = true;
+				_instance = this;
 			}
 		}
 


### PR DESCRIPTION
## Description of Changes
*Describe what has been changed, any new features or bug fixes*

- switched our "already connected" logic to using a reference to a `MonoBehaviour` instead of just a bool. `MonoBehaviour`s are typically destroyed when a scene reload happens and in this case we'll want to allow developers to spawn a new `SpacetimeDBNetworkManager` if the previous one has been destroyed.

## API

This is *not* an API break.

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*

## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*

## Testing
*Write instructions for a test that you performed for this PR*

- [x] Checkout the SpacetimeDBCircleGame project
- [x] Remove SpacetimeDB package and add a new one: `https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk.git#jdetter-fix-reconnection-logic`
- [x] Add a simple function to the GameManager which reloads the scene in order to cause a reconnection:
```csharp
private void Start() 
{
    // add this to the bottom of start
    StartCoroutine(Reconnect());
}

public IEnumerator Reconnect() 
{
    yield return new WaitForSeconds(3.0f);
    // Reload the scene to cause a reconnection
    UnityEngine.SceneManagement.SceneManager.LoadScene("Scenes/SampleScene");
}
``` 

Previously, before this PR you would end up with:
```
Unhandled log message: '[Exception] InvalidOperationException: SpacetimeDBNetworkManager is a singleton and should only be attached once.'. Use UnityEngine.TestTools.LogAssert.Expect
```

After this PR it just works with no error.