### PR TITLE
Fixed subscription updates not clearing tables with no subscribed values

### DIFF
--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -547,7 +547,10 @@ namespace SpacetimeDB
                 {
                     if (!subscriptionInserts.TryGetValue(table.ClientTableType, out var hashSet))
                     {
-                        continue;
+                        // We still need to process tables that weren't included in subscription.
+                        // Otherwise we won't delete no-longer-available values
+                        hashSet = new HashSet<byte[]>();
+                        subscriptionInserts.Add(table.ClientTableType, hashSet);
                     }
 
                     foreach (var (rowBytes, oldValue) in table.IterEntries().Where(kv => !hashSet.Contains(kv.Key)))


### PR DESCRIPTION
## Description of Changes
*Describe what has been changed, any new features or bug fixes*

Context: https://discord.com/channels/568217153853980682/669989878955638785/1301132060878049332
Currently, when we receive subscription updates, a table will only be diffed if subscription has any rows for that table. If, however, there are no subscribed values, that table will NOT be diffed, and therefore will not get cleared. Values from previous subscription will still be there, so the table is in incorrect state. 

This PR fixes that by making sure that ALL tables are checked in state diff

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*

## Testing
*Write instructions for a test that you performed for this PR*

- [ ] Create a table A with an `val: i32` field
- [ ] Generate rows for table A with field values in the range (0..100)
- [ ] Connect client and subscribe to `SELECT * FROM A WHERE val > 0` (will have all rows from table A)
- [ ] Change your subscription to `SELECT * FROM A WHERE val > 1000` (should have no rows)
- [ ] Note that after subscription is applied, table A will have no values