### PR TITLE
Fix connection string generation

### DIFF
--- a/src/WebSocket.cs
+++ b/src/WebSocket.cs
@@ -52,7 +52,7 @@ namespace SpacetimeDB
 
         public async Task Connect(string? auth, string host, string nameOrAddress, Address clientAddress, Compression compression, bool light)
         {
-            var uri = $"{host}/database/subscribe/{nameOrAddress}?client_address={clientAddress}&compression={nameof(compression)}";
+            var uri = $"{host}/database/subscribe/{nameOrAddress}?client_address={clientAddress}&compression={compression}";
             if (light)
             {
                 uri += "&light=true";


### PR DESCRIPTION
## Description of Changes

nameof returns the name of the variable, not the name of the enum value it represents. ToString does this automatically

## Testing

Websocket didnt connect before, it does now