### PR TITLE
Unity testsuite as a git submodule

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,15 @@
 
 *If the API is breaking, please state below what will break*
 
-
 ## Requires SpacetimeDB PRs
 *List any PRs here that are required for this SDK change to work*
+
+## Testsuite
+*If you would like to run against a specific SpacetimeDB branch in the testsuite, specify that here. This can be a branch name or a link to a PR.*
+
+SpacetimeDB branch name: master
+
+## Testing
+*Write instructions for a test that you performed for this PR*
+
+- [ ] Describe a test for this PR that you have completed

--- a/.github/workflows/unity-test.yml
+++ b/.github/workflows/unity-test.yml
@@ -20,6 +20,7 @@ jobs:
           cd ..
           git config -f .gitmodules submodule.unity-tests~.url https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk
           git submodule sync
+          git submodule init
           git submodule update
 
       # Grab the branch name from the PR description. If it's not found, master will be used instead.

--- a/.github/workflows/unity-test.yml
+++ b/.github/workflows/unity-test.yml
@@ -68,16 +68,20 @@ jobs:
           rustup install stable
           rustup default stable
 
-      - uses: actions/cache@v3
+      - name: Cache Cargo target directory
+        uses: actions/cache@v3
         with:
           path: |
             unity-tests~/server/target
             ~/.cargo
-          key: server-target-SpacetimeDBUnityTestsuite-Linux-x86-${{ runner.os }}-${{ hashFiles('unity-tests~/server/Cargo.lock') }}
+          key: server-target-SpacetimeDBUnityTestsuite-Linux-x86-${{ runner.os }}-${{ runner.arch }}
           restore-keys: |
-            server-target-SpacetimeDBUnityTestsuite-Linux-x86-${{ runner.os }}-
+            server-target-SpacetimeDBUnityTestsuite-Linux-x86-${{ runner.os }}-${{ runner.arch }}
+            server-target-SpacetimeDBUnityTestsuite-Linux-x86-
             server-target-SpacetimeDBUnityTestsuite-
-
+          enableCrossOsArchive: false
+          fail-on-cache-miss: false
+          lookup-only: false
       - name: Install SpacetimeDB CLI from specific branch
         run: |
           cd unity-tests~

--- a/.github/workflows/unity-test.yml
+++ b/.github/workflows/unity-test.yml
@@ -15,7 +15,11 @@ jobs:
 
       - name: Checkout Submodules
         run: |
-          git submodule init
+          cd unity-tests~
+          git config remote.origin.url https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk
+          cd ..
+          git config -f .gitmodules submodule.unity-tests~.url https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk
+          git submodule sync
           git submodule update
 
       # Grab the branch name from the PR description. If it's not found, master will be used instead.

--- a/.github/workflows/unity-test.yml
+++ b/.github/workflows/unity-test.yml
@@ -57,7 +57,7 @@ jobs:
           # Get the branch name from the environment variable
           branch_name="${{ github.head_ref }}"
           # Make sure we're using the correct bindings when building the module TODO
-          sed -i "s|spacetimedb.*=|spacetimedb = \{ path = \"../SpacetimeDB/crates/bindings\"\}|" unity-tests~/server/Cargo.toml
+          sed -i "s|spacetimedb.*=.*|spacetimedb = \{ path = \"../SpacetimeDB/crates/bindings\"\}|" unity-tests~/server/Cargo.toml
           cat unity-tests~/server/Cargo.toml
           exit 1
       - name: Install Rust toolchain

--- a/.github/workflows/unity-test.yml
+++ b/.github/workflows/unity-test.yml
@@ -1,0 +1,127 @@
+name: Unity Test Suite
+
+on:
+  push:
+    branches:
+      - staging
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Grab the branch name from the PR description. If it's not found, master will be used instead.
+      - name: Extract SpacetimeDB branch name or PR link from PR description
+        id: extract-branch
+        if: github.event_name == 'pull_request'
+        run: |
+          description=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          ${{ github.event.pull_request.url }} | jq -r '.body')
+
+          # Check if description contains a branch name or a PR link
+          branch_or_pr=$(echo "$description" | grep -oP '(?<=SpacetimeDB branch name:\s).+')
+          echo "Branch or PR found: $branch_or_pr"
+
+          if [[ -z "$branch_or_pr" ]]; then
+            branch="master"
+          elif [[ "$branch_or_pr" =~ ^https://github.com/.*/pull/[0-9]+$ ]]; then
+            # If it's a PR link, extract the branch name from the PR
+            pr_number=$(echo "$branch_or_pr" | grep -oP '[0-9]+$')
+            branch=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/clockworklabs/SpacetimeDB/pulls/$pr_number | jq -r '.head.ref')
+          else
+            # It's already a branch name
+            branch="$branch_or_pr"
+          fi
+
+          echo "branch=$branch" >> $GITHUB_OUTPUT
+          echo "Final branch name: $branch"
+
+      - name: Replace com.clockworklabs.spacetimedbsdk in manifest.json
+        run: |
+          # Get the branch name from the environment variable
+          branch_name="${{ github.head_ref }}"
+          # Replace any reference to com.clockworklabs.spacetimedbsdk with the correct GitHub URL using the current branch
+          sed -i "s|\"com.clockworklabs.spacetimedbsdk\":.*|\"com.clockworklabs.spacetimedbsdk\": \"https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk.git#$branch_name\",|" unity-tests~/client/Packages/manifest.json
+
+          cat unity-tests~/client/Packages/manifest.json
+      - name: Replace spacetimedb dependency in Cargo.toml
+        run: |
+          # Get the branch name from the environment variable
+          branch_name="${{ github.head_ref }}"
+          # Make sure we're using the correct bindings when building the module TODO
+          sed -i "s|spacetimedb.*=|spacetimedb = \{ path = \"../SpacetimeDB/crates/bindings\"\}|" unity-tests~/server/Cargo.toml
+          cat unity-tests~/server/Cargo.toml
+          exit 1
+      - name: Install Rust toolchain
+        run: |
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+          source $HOME/.cargo/env
+          rustup install stable
+          rustup default stable
+
+      - name: Install SpacetimeDB CLI from specific branch
+        run: |
+          cd unity-tests~
+          git clone https://github.com/clockworklabs/SpacetimeDB.git
+          cd SpacetimeDB
+          # Sanitize the branch name by trimming any newlines or spaces
+          branch_name=$(echo "${{ steps.extract-branch.outputs.branch }}" | tr -d '[:space:]')
+          # If the branch name is not found, default to master
+          if [ -z "$branch_name" ]; then
+            branch_name="master"
+          fi
+          git checkout "$branch_name"
+          echo "Checked out branch: $branch_name"
+          cargo build --release -p spacetimedb-cli
+          sudo mv target/release/spacetime /usr/bin/spacetime
+
+      - name: Generate client bindings
+        run: |
+          cd unity-tests~/server
+          bash ./generate.sh -y
+
+      - name: Start SpacetimeDB
+        run: |
+          spacetime start &
+          disown
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            unity-tests~/server/target
+            ~/.cargo
+          key: server-target-SpacetimeDBUnityTestsuite-Linux-x86-${{ runner.os }}-${{ hashFiles('unity-tests~/server/Cargo.lock') }}
+          restore-keys: |
+            server-target-SpacetimeDBUnityTestsuite-Linux-x86-${{ runner.os }}-
+            server-target-SpacetimeDBUnityTestsuite-
+
+      - name: Publish module to SpacetimeDB
+        run: |
+          cd unity-tests~/server
+          bash ./publish.sh
+
+      - uses: actions/cache@v3
+        with:
+          path: unity-tests~/client/Library
+          key: Library-SpacetimeDBUnityTestsuite-Linux-x86
+          restore-keys: |
+            Library-SpacetimeDBUnityTestsuite-
+            Library-
+
+      - name: Set up Unity
+        uses: game-ci/unity-test-runner@v4
+        with:
+          unityVersion: 2022.3.32f1  # Adjust Unity version to a valid tag
+          projectPath: unity-tests~/client  # Path to the Unity project subdirectory
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          testMode: playmode
+          useHostNetwork: true
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+

--- a/.github/workflows/unity-test.yml
+++ b/.github/workflows/unity-test.yml
@@ -71,17 +71,30 @@ jobs:
       - name: Cache Cargo target directory
         uses: actions/cache@v3
         with:
-          path: |
-            unity-tests~/server/target
-            ~/.cargo
-          key: server-target-SpacetimeDBUnityTestsuite-Linux-x86-Linux-X64
+          path: unity-tests~/server/target
+          key: server-target-SpacetimeDBUnityTestsuite-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('unity-tests~/server/Cargo.lock') }}
           restore-keys: |
-            server-target-SpacetimeDBUnityTestsuite-Linux-x86-Linux-X64
-            server-target-SpacetimeDBUnityTestsuite-Linux-x86-
+            server-target-SpacetimeDBUnityTestsuite-${{ runner.os }}-${{ runner.arch }}-
             server-target-SpacetimeDBUnityTestsuite-
-          enableCrossOsArchive: false
-          fail-on-cache-miss: false
-          lookup-only: false
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry-${{ runner.os }}-${{ hashFiles('unity-tests~/server/Cargo.lock') }}
+          restore-keys: |
+            cargo-registry-${{ runner.os }}-
+            cargo-registry-
+
+      - name: Cache Cargo index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: cargo-index-${{ runner.os }}-${{ hashFiles('unity-tests~/server/Cargo.lock') }}
+          restore-keys: |
+            cargo-index-${{ runner.os }}-
+            cargo-index-
+
       - name: Install SpacetimeDB CLI from specific branch
         run: |
           cd unity-tests~

--- a/.github/workflows/unity-test.yml
+++ b/.github/workflows/unity-test.yml
@@ -57,15 +57,24 @@ jobs:
           # Get the branch name from the environment variable
           branch_name="${{ github.head_ref }}"
           # Make sure we're using the correct bindings when building the module TODO
-          sed -i "s|spacetimedb.*=.*|spacetimedb = \{ path = \"../SpacetimeDB/crates/bindings\"\}|" unity-tests~/server/Cargo.toml
+          sed -i "s|spacetimedb.*=.*|spacetimedb = \{ path = \"../SpacetimeDB/crates/bindings\" \}|" unity-tests~/server/Cargo.toml
           cat unity-tests~/server/Cargo.toml
-          exit 1
       - name: Install Rust toolchain
         run: |
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           source $HOME/.cargo/env
           rustup install stable
           rustup default stable
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            unity-tests~/server/target
+            ~/.cargo
+          key: server-target-SpacetimeDBUnityTestsuite-Linux-x86-${{ runner.os }}-${{ hashFiles('unity-tests~/server/Cargo.lock') }}
+          restore-keys: |
+            server-target-SpacetimeDBUnityTestsuite-Linux-x86-${{ runner.os }}-
+            server-target-SpacetimeDBUnityTestsuite-
 
       - name: Install SpacetimeDB CLI from specific branch
         run: |
@@ -92,16 +101,6 @@ jobs:
         run: |
           spacetime start &
           disown
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            unity-tests~/server/target
-            ~/.cargo
-          key: server-target-SpacetimeDBUnityTestsuite-Linux-x86-${{ runner.os }}-${{ hashFiles('unity-tests~/server/Cargo.lock') }}
-          restore-keys: |
-            server-target-SpacetimeDBUnityTestsuite-Linux-x86-${{ runner.os }}-
-            server-target-SpacetimeDBUnityTestsuite-
 
       - name: Publish module to SpacetimeDB
         run: |

--- a/.github/workflows/unity-test.yml
+++ b/.github/workflows/unity-test.yml
@@ -13,12 +13,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Force Submodule to use HTTPS instead of SSH
+      - name: Checkout submodule
         run: |
-          git submodule deinit -f --all
-          git config -f .gitmodules submodule.unity-tests~.url https://github.com/clockworklabs/SpacetimeDBCircleGame
-          git submodule sync --recursive
-          git submodule update --init --recursive
+          git submodule init
+          git submodule update
       # Grab the branch name from the PR description. If it's not found, master will be used instead.
       - name: Extract SpacetimeDB branch name or PR link from PR description
         id: extract-branch

--- a/.github/workflows/unity-test.yml
+++ b/.github/workflows/unity-test.yml
@@ -17,6 +17,8 @@ jobs:
         run: |
           git submodule init
           git submodule update
+          cd unity-tests~
+          git checkout jdetter/circle-game-testsuite
       # Grab the branch name from the PR description. If it's not found, master will be used instead.
       - name: Extract SpacetimeDB branch name or PR link from PR description
         id: extract-branch

--- a/.github/workflows/unity-test.yml
+++ b/.github/workflows/unity-test.yml
@@ -13,16 +13,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Checkout Submodules
+      - name: Force Submodule to use HTTPS instead of SSH
         run: |
-          cd unity-tests~
-          git config remote.origin.url https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk
-          cd ..
-          git config -f .gitmodules submodule.unity-tests~.url https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk
-          git submodule sync
-          git submodule init
-          git submodule update
-
+          git submodule deinit -f --all
+          git config -f .gitmodules submodule.unity-tests~.url https://github.com/clockworklabs/SpacetimeDBCircleGame
+          git submodule sync --recursive
+          git submodule update --init --recursive
       # Grab the branch name from the PR description. If it's not found, master will be used instead.
       - name: Extract SpacetimeDB branch name or PR link from PR description
         id: extract-branch

--- a/.github/workflows/unity-test.yml
+++ b/.github/workflows/unity-test.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Checkout Submodules
+        run: |
+          git submodule init
+          git submodule update
+
       # Grab the branch name from the PR description. If it's not found, master will be used instead.
       - name: Extract SpacetimeDB branch name or PR link from PR description
         id: extract-branch

--- a/.github/workflows/unity-test.yml
+++ b/.github/workflows/unity-test.yml
@@ -74,9 +74,9 @@ jobs:
           path: |
             unity-tests~/server/target
             ~/.cargo
-          key: server-target-SpacetimeDBUnityTestsuite-Linux-x86-${{ runner.os }}-${{ runner.arch }}
+          key: server-target-SpacetimeDBUnityTestsuite-Linux-x86-Linux-X64
           restore-keys: |
-            server-target-SpacetimeDBUnityTestsuite-Linux-x86-${{ runner.os }}-${{ runner.arch }}
+            server-target-SpacetimeDBUnityTestsuite-Linux-x86-Linux-X64
             server-target-SpacetimeDBUnityTestsuite-Linux-x86-
             server-target-SpacetimeDBUnityTestsuite-
           enableCrossOsArchive: false

--- a/.github/workflows/unity-testsuite-bindings.yml
+++ b/.github/workflows/unity-testsuite-bindings.yml
@@ -1,0 +1,87 @@
+name: Check Unity Testsuite Bindings
+
+on:
+  push:
+    branches:
+      - staging
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Replace spacetimedb dependency in Cargo.toml
+        run: |
+          # Get the branch name from the environment variable
+          branch_name="${{ github.head_ref }}"
+          # Make sure we're using the correct bindings when building the module TODO
+          sed -i "s|spacetimedb.*=|spacetimedb = \{ path = \"../SpacetimeDB/crates/bindings\"\}|" unity-tests~/server/Cargo.   toml
+          cat unity-tests~/server/Cargo.toml
+
+      # Grab the branch name from the PR description. If it's not found, master will be used instead.
+      - name: Extract SpacetimeDB branch name or PR link from PR description
+        id: extract-branch
+        if: github.event_name == 'pull_request'
+        run: |
+          description=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          ${{ github.event.pull_request.url }} | jq -r '.body')
+
+          # Check if description contains a branch name or a PR link
+          branch_or_pr=$(echo "$description" | grep -oP '(?<=SpacetimeDB branch name:\s).+')
+          echo "Branch or PR found: $branch_or_pr"
+
+          if [[ -z "$branch_or_pr" ]]; then
+            branch="master"
+          elif [[ "$branch_or_pr" =~ ^https://github.com/.*/pull/[0-9]+$ ]]; then
+            # If it's a PR link, extract the branch name from the PR
+            pr_number=$(echo "$branch_or_pr" | grep -oP '[0-9]+$')
+            branch=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/clockworklabs/SpacetimeDB/pulls/$pr_number | jq -r '.head.ref')
+          else
+            # It's already a branch name
+            branch="$branch_or_pr"
+          fi
+
+          echo "branch=$branch" >> $GITHUB_OUTPUT
+          echo "Final branch name: $branch"
+      - name: Install Rust toolchain
+        run: |
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+          source $HOME/.cargo/env
+          rustup install stable
+          rustup default stable
+
+      - name: Install SpacetimeDB CLI from specific branch
+        run: |
+          cd unity-tests~
+          git clone https://github.com/clockworklabs/SpacetimeDB.git
+          cd SpacetimeDB
+          # Sanitize the branch name by trimming any newlines or spaces
+          branch_name=$(echo "${{ steps.extract-branch.outputs.branch }}" | tr -d '[:space:]')
+          # If the branch name is not found, default to master
+          if [ -z "$branch_name" ]; then
+            branch_name="master"
+          fi
+          git checkout "$branch_name"
+          echo "Checked out branch: $branch_name"
+          cargo build --release -p spacetimedb-cli
+          sudo mv target/release/spacetime /usr/bin/spacetime
+
+      - name: Generate client bindings
+        run: |
+          cd unity-tests~/server
+          bash ./generate.sh -y
+
+      - name: Check for changes
+        run: |
+          git diff --exit-code
+        continue-on-error: true
+
+      - name: Fail if there are changes
+        if: ${{ steps.check-for-changes.outcome == 'failure' }}
+        run: |
+          echo "Error: Bindings are dirty. Please generate bindings again and commit them to this branch."
+          exit 1

--- a/.github/workflows/unity-testsuite-bindings.yml
+++ b/.github/workflows/unity-testsuite-bindings.yml
@@ -13,14 +13,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Replace spacetimedb dependency in Cargo.toml
+      - name: Checkout submodule
         run: |
-          # Get the branch name from the environment variable
-          branch_name="${{ github.head_ref }}"
-          # Make sure we're using the correct bindings when building the module TODO
-          sed -i "s|spacetimedb.*=|spacetimedb = \{ path = \"../SpacetimeDB/crates/bindings\"\}|" unity-tests~/server/Cargo.   toml
-          cat unity-tests~/server/Cargo.toml
-
+          git submodule init
+          git submodule update
+          cd unity-tests~
+          git checkout jdetter/circle-game-testsuite
       # Grab the branch name from the PR description. If it's not found, master will be used instead.
       - name: Extract SpacetimeDB branch name or PR link from PR description
         id: extract-branch
@@ -47,12 +45,47 @@ jobs:
 
           echo "branch=$branch" >> $GITHUB_OUTPUT
           echo "Final branch name: $branch"
+
+      - name: Replace spacetimedb dependency in Cargo.toml
+        run: |
+          # Get the branch name from the environment variable
+          branch_name="${{ github.head_ref }}"
+          # Make sure we're using the correct bindings when building the module TODO
+          sed -i "s|spacetimedb.*=.*|spacetimedb = \{ path = \"../SpacetimeDB/crates/bindings\" \}|" unity-tests~/server/Cargo.toml
+          cat unity-tests~/server/Cargo.toml
       - name: Install Rust toolchain
         run: |
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           source $HOME/.cargo/env
           rustup install stable
           rustup default stable
+
+      - name: Cache Cargo target directory
+        uses: actions/cache@v3
+        with:
+          path: unity-tests~/server/target
+          key: server-target-SpacetimeDBUnityTestsuite-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('unity-tests~/server/Cargo.lock') }}
+          restore-keys: |
+            server-target-SpacetimeDBUnityTestsuite-${{ runner.os }}-${{ runner.arch }}-
+            server-target-SpacetimeDBUnityTestsuite-
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry-${{ runner.os }}-${{ hashFiles('unity-tests~/server/Cargo.lock') }}
+          restore-keys: |
+            cargo-registry-${{ runner.os }}-
+            cargo-registry-
+
+      - name: Cache Cargo index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: cargo-index-${{ runner.os }}-${{ hashFiles('unity-tests~/server/Cargo.lock') }}
+          restore-keys: |
+            cargo-index-${{ runner.os }}-
+            cargo-index-
 
       - name: Install SpacetimeDB CLI from specific branch
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "SpacetimeDBCircleGame"]
 	path = unity-tests~
-	url = ssh://git@github.com/clockworklabs/SpacetimeDBCircleGame
+	url = https://github.com/clockworklabs/SpacetimeDBCircleGame

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "SpacetimeDBCircleGame"]
+	path = unity-tests~
+	url = ssh://git@github.com/clockworklabs/SpacetimeDBCircleGame


### PR DESCRIPTION
**Please do not rebase this PR**

## Description of Changes
*Describe what has been changed, any new features or bug fixes*

This is very similar to https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/pull/176 except it imports the circle game as a submodule instead of copying the code over into this repo. This is the SpacetimeDBCircleGame PR that we're dependent on right now: https://github.com/clockworklabs/SpacetimeDBCircleGame/pull/3

- This PR introduces a testsuite which runs in Unity. Right now it just spawns in a circle, eats some food and verifies the decay logic is working correctly. I've also written some reconnection tests but they don't work because reconnections are currently broken. There are also one-off tests but those don't work either because they also require reconnections to be working.

Update: reconnections have been fixed via https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/pull/168.

I've used the built-in unity testsuite framework to achieve this, along with the UnityCI tool from GameCI. The documentation for this docker container can be found here: https://game.ci/docs/github/getting-started/

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*

Not breaking

## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*

None

## Testsuite

SpacetimeDB branch name: 0935b7346b825b8cbb9f36d9ed256136b73b5f0b

## Testing
*Write instructions for a test that you performed for this PR*

- [x] The testsuite is passing: https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/actions/runs/11604456943/job/32313229775

You can follow test instructions here to double check my work: https://github.com/clockworklabs/SpacetimeDBCircleGame/pull/3

## Follow-up Actions

- [ ] Rebase the reconnection logic PR onto this PR and re-enable the reconnection tests