### PR TITLE
Bump Unity SDK version to RC1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.clockworklabs.spacetimedbsdk",
   "displayName": "SpacetimeDB SDK",
-  "version": "1.0.0",
+  "version": "1.0.0-rc1",
   "description": "The SpacetimeDB Client SDK is a software development kit (SDK) designed to interact with and manipulate SpacetimeDB modules..",
   "keywords": [],
   "author": {


### PR DESCRIPTION
## Description of Changes
Just bump `package.json` to `1.0.0-rc1` instead of `1.0.0`.

## API
No breaking changes

## Requires SpacetimeDB PRs
None

## Testing
