### PR TITLE
Add delegates for events

### DIFF
--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -75,19 +75,25 @@ namespace SpacetimeDB
             return this;
         }
 
-        public DbConnectionBuilder<DbConnection, Reducer> OnConnect(Action<DbConnection, Identity, string> cb)
+        public delegate void ConnectCallback(DbConnection conn, Identity identity, string token);
+
+        public DbConnectionBuilder<DbConnection, Reducer> OnConnect(ConnectCallback cb)
         {
             conn.onConnect += (identity, token) => cb.Invoke(conn, identity, token);
             return this;
         }
 
-        public DbConnectionBuilder<DbConnection, Reducer> OnConnectError(Action<Exception> cb)
+        public delegate void ConnectErrorCallback(Exception e);
+
+        public DbConnectionBuilder<DbConnection, Reducer> OnConnectError(ConnectErrorCallback cb)
         {
             conn.webSocket.OnConnectError += (e) => cb.Invoke(e);
             return this;
         }
 
-        public DbConnectionBuilder<DbConnection, Reducer> OnDisconnect(Action<DbConnection, Exception?> cb)
+        public delegate void DisconnectCallback(DbConnection conn, Exception? e);
+
+        public DbConnectionBuilder<DbConnection, Reducer> OnDisconnect(DisconnectCallback cb)
         {
             conn.webSocket.OnClose += (e) => cb.Invoke(conn, e);
             return this;

--- a/src/Table.cs
+++ b/src/Table.cs
@@ -94,10 +94,13 @@ namespace SpacetimeDB
         // The function to use for decoding a type value.
         IDatabaseRow IRemoteTableHandle.DecodeValue(byte[] bytes) => BSATNHelpers.Decode<Row>(bytes);
 
-        public event Action<EventContext, Row>? OnInsert;
-        public event Action<EventContext, Row>? OnDelete;
-        public event Action<EventContext, Row>? OnBeforeDelete;
-        public event Action<EventContext, Row, Row>? OnUpdate;
+        public delegate void RowEventHandler(EventContext context, Row row);
+        public event RowEventHandler? OnInsert;
+        public event RowEventHandler? OnDelete;
+        public event RowEventHandler? OnBeforeDelete;
+
+        public delegate void UpdateEventHandler(EventContext context, Row oldRow, Row newRow);
+        public event UpdateEventHandler? OnUpdate;
 
         public int Count => Entries.Count;
 


### PR DESCRIPTION
## Description of Changes

This is a requested DX improvement to make sure that IDE shows reasonable argument names instead of `arg0`...`argN`.

Fixes https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/issues/200.

## API

 - [x] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*

Potentially breaking in obscure edge cases, if someone already had `Action<...> myCallback;` that they passed to those APIs as C# won't cast it automatically to our custom delegate type.

## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*

## Testsuite
*If you would like to run against a specific SpacetimeDB branch in the testsuite, specify that here. This can be a branch name or a link to a PR.*

SpacetimeDB branch name: master

## Testing
*Write instructions for a test that you performed for this PR*

- [x] `dotnet test`
