### PR TITLE
fix(202): RemoteQuery should not SELECT *

### DIFF
--- a/src/Table.cs
+++ b/src/Table.cs
@@ -106,7 +106,7 @@ namespace SpacetimeDB
         protected IEnumerable<Row> Query(Func<Row, bool> filter) => Iter().Where(filter);
 
         public Task<Row[]> RemoteQuery(string query) =>
-            conn!.RemoteQuery<Row>($"SELECT * FROM {name!} {query}");
+            conn!.RemoteQuery<Row>($"SELECT {name!}.* FROM {name!} {query}");
 
         void IRemoteTableHandle.InvokeInsert(IEventContext context, IDatabaseRow row) =>
             OnInsert?.Invoke((EventContext)context, (Row)row);


### PR DESCRIPTION
Fixes #202.

Because SELECT * is ambiguous if the query is a join

## Description of Changes

Bug Fix

Previously `RemoteQuery` would implicitly `SELECT *`. This was wrong because you can use `RemoteQuery` to issue join queries.

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*

## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*

## Testsuite
*If you would like to run the your SDK changes in this PR against a specific SpacetimeDB branch, specify that here. This can be a branch name or a link to a PR.*

SpacetimeDB branch name: v1.0.0-rc1

## Testing

NOTE: This patch is untested. The risk is minimal given the simplicity of the fix. I looked for some example tests that I could extend, but didn't see anything applicable. Nevertheless it would still be useful to add a regression test.
