### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup SpacetimeDB packages
       working-directory: spacetimedb-csharp-sdk
       run: |
-        ( cd ../SpacetimeDB/crates/bindings-csharp/BSATN.Runtime && dotnet pack )
+        dotnet pack ../SpacetimeDB/crates/bindings-csharp/BSATN.Runtime /p:TargetFramework=netstandard2.1
 
         # Write out the nuget config file to `nuget.config`. This causes the spacetimedb-csharp-sdk repository
         # to be aware of the local versions of the `bindings-csharp` packages in SpacetimeDB, and use them if

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup SpacetimeDB packages
       working-directory: spacetimedb-csharp-sdk
       run: |
-        dotnet pack ../SpacetimeDB/crates/bindings-csharp/BSATN.Runtime /p:TargetFrameworks=netstandard2.1
+        dotnet pack ../SpacetimeDB/crates/bindings-csharp/BSATN.Runtime
 
         # Write out the nuget config file to `nuget.config`. This causes the spacetimedb-csharp-sdk repository
         # to be aware of the local versions of the `bindings-csharp` packages in SpacetimeDB, and use them if

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup SpacetimeDB packages
       working-directory: spacetimedb-csharp-sdk
       run: |
-        dotnet pack ../SpacetimeDB/crates/bindings-csharp/BSATN.Runtime /p:TargetFramework=netstandard2.1
+        dotnet pack ../SpacetimeDB/crates/bindings-csharp/BSATN.Runtime /p:TargetFrameworks=netstandard2.1
 
         # Write out the nuget config file to `nuget.config`. This causes the spacetimedb-csharp-sdk repository
         # to be aware of the local versions of the `bindings-csharp` packages in SpacetimeDB, and use them if

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Checkout SpacetimeDB
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
## Description of Changes

I don't know when or why this broke (or, rather, how it worked before), but we're installing .NET 7 but packing BSATN.Runtime that multi-targets .NET Standard 2.1 + .NET 8. The latter part, as you'd expect, fails on CI.

~~This change tells `dotnet pack` to only pack for .NET Standard 2.1 since that's the one we're interested in on the client - .NET 8 support is only for C# server modules.~~ _Narrator: that didn't work out._

This change bumps .NET SDK to 8.0 because I still don't know how it worked before with .NET 7, and this seems like the more sensible solution anyway.

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*

## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*

## Testsuite
*If you would like to run the your SDK changes in this PR against a specific SpacetimeDB branch, specify that here. This can be a branch name or a link to a PR.*

SpacetimeDB branch name: master

## Testing
*Write instructions for a test that you performed for this PR*

- [ ] Describe a test for this PR that you have completed
