### PR TITLE
Disable PR comment for meta file check if not a PR

### DIFF
--- a/.github/workflows/unity-test.yml
+++ b/.github/workflows/unity-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check Unity meta files
         uses: DeNA/unity-meta-check@v3
         with:
-          enable_pr_comment: true
+          enable_pr_comment: ${{ github.event_name == 'pull_request' }}
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
## Description of Changes

Looks like the .meta check hard-fails on push events if `enable_pr_comment` is `true`, instead of just ignoring it...

I hope this fix works, but hard to tell without merging first.

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*

## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*

## Testsuite
*If you would like to run the your SDK changes in this PR against a specific SpacetimeDB branch, specify that here. This can be a branch name or a link to a PR.*

SpacetimeDB branch name: master

## Testing
*Write instructions for a test that you performed for this PR*

- [x] This is a PR that changes CI configuration, so see CI
