### PR TITLE
Revert trunk branch versions to `1.0.0-rc3` (no hotfix)

### DIFF
--- a/SpacetimeDB.ClientSDK.csproj
+++ b/SpacetimeDB.ClientSDK.csproj
@@ -17,14 +17,14 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk</RepositoryUrl>
     <AssemblyVersion>1.0.0</AssemblyVersion>
-    <Version>1.0.0-rc3-hotfix3</Version>
+    <Version>1.0.0-rc3</Version>
     <DefaultItemExcludes>$(DefaultItemExcludes);*~/**</DefaultItemExcludes>
     <!-- We want to save DLLs for Unity which doesn't support NuGet. -->
     <RestorePackagesPath>packages</RestorePackagesPath>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.BSATN.Runtime" Version="1.0.0-rc3-hotfix3" />
+    <PackageReference Include="SpacetimeDB.BSATN.Runtime" Version="1.0.0-rc3" />
 
     <InternalsVisibleTo Include="SpacetimeDB.Tests" />
   </ItemGroup>


### PR DESCRIPTION
## Description of Changes
Remove the `-hotfix*` part of the version in our trunk branch.

It was a (my) mistake to merge a `-hotfix*` version change. Hotfixes are, by definition, cherry-picked changes that are going to be released directly to users without merging.

The consequence of merging this change was that the `SDK Tests` CI job started failing on SpacetimeDB PRs (e.g. see failures on https://github.com/clockworklabs/SpacetimeDB/pull/2137), because it checks out this repo, which then tried to use the `-hotifx3` version of SpacetimeDB. But the `master` branch of SpacetimeDB is at `1.0.0-rc3` (no hotfix), because the hotfix was correctly released from a branch without merging in that repo.

Although this PR reverts the version change, we do still have a tag `v1.0.0-rc3-hotfix3` that we can use to release the hotfix version (by `git push -f origin v1.0.0-rc3-hotfix3:master`) if/when desired.

## API

 - [ ] This is an API breaking change to the SDK

No

## Requires SpacetimeDB PRs
Should work with `master`.

## Testsuite
*If you would like to run the your SDK changes in this PR against a specific SpacetimeDB branch, specify that here. This can be a branch name or a link to a PR.*

SpacetimeDB branch name: master

## Testing
I claim that the CI tests passing with `master` show that this is correct. The original version change itself passed CI because it was pointing at a non-`master` branch for testing. I claim it would have failed if it were tested against SpacetimeDB `master`.

Generally, this might point to a bug in how we've done this CI: We should probably only allow a PR to merge in this repo if it tests successfully against SpacetimeDB `master`, even if we want to point it at other branches to test in the meantime.