### PR TITLE
CI - Update release branch check

### DIFF
--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -8,15 +8,15 @@ permissions: read-all
 
 jobs:
   check_base_ref:
-    name: Only release branches may merge into master
+    name: Release branch restriction
     runs-on: ubuntu-latest
     steps:
       - id: not_based_on_master
         if: |
           github.event_name == 'pull_request' &&
-          github.event.pull_request.base.ref == 'master' &&
+          github.event.pull_request.base.ref == 'release/latest' &&
           ! startsWith(github.event.pull_request.head.ref, 'release/')
         run: |
-          echo 'Only `release/*` branches are allowed to merge into `master`.'
-          echo 'Maybe your PR should be merging into `staging`?'
+          echo 'Only `release/*` branches are allowed to merge into the release branch `release/latest`.'
+          echo 'Maybe you want to change your PR base to `master`?'
           exit 1


### PR DESCRIPTION
## Description of Changes
This updates the CI check protecting the release branch, as part of https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/issues/226 (see that ticket for more details).

Once this is merged, it will need to be cherrypicked into our release branch in order to take effect there.

The check itself has also been renamed. I have already updated the branch protection rules to look for the new name.

## API

No code changes.

## Requires SpacetimeDB PRs
None

## Testsuite
SpacetimeDB branch name: master

## Testing
The previous behavior was well-tested, and I've just changed some strings here, so I have not done further testing. It does pass on this branch though.