### PR TITLE
Fix comment for SubscribeToAllTables

### DIFF
--- a/examples~/quickstart/client/module_bindings/SpacetimeDBClient.g.cs
+++ b/examples~/quickstart/client/module_bindings/SpacetimeDBClient.g.cs
@@ -367,6 +367,7 @@ namespace SpacetimeDB.Types
         /// Applications where these resources are a constraint
         /// should register more precise queries via <c>Self.Subscribe</c>
         /// in order to replicate only the subset of data which the client needs to function.
+        /// </summary>
         public void SubscribeToAllTables()
         {
             // Make sure we use the legacy handle constructor here, even though there's only 1 query.


### PR DESCRIPTION
## Description of Changes

Adds closing `</summary>` to end of comment.

## API

No breaking changes

## Requires SpacetimeDB PRs

N/A

## Testsuite
*If you would like to run the your SDK changes in this PR against a specific SpacetimeDB branch, specify that here. This can be a branch name or a link to a PR.*

SpacetimeDB branch name: master

## Testing

Just fixing a comment. No tests required.
