### PR TITLE
Relax the version constraint on SpacetimeDB nuget package

### DIFF
--- a/SpacetimeDB.ClientSDK.csproj
+++ b/SpacetimeDB.ClientSDK.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.BSATN.Runtime" Version="1.0.0" />
+    <PackageReference Include="SpacetimeDB.BSATN.Runtime" Version="1.0.*" />
 
     <InternalsVisibleTo Include="SpacetimeDB.Tests" />
   </ItemGroup>


### PR DESCRIPTION
## Description of Changes
Relaxed this version number from `1.0.0` to `1.0.*`

## API
No breaking changes.

## Requires SpacetimeDB PRs
None

## Testsuite

SpacetimeDB branch name: master

## Testing
Existing CI should run `dotnet test` and confirm that this is not broken.