### PR TITLE
Bump package version to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.clockworklabs.spacetimedbsdk",
   "displayName": "SpacetimeDB SDK",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The SpacetimeDB Client SDK is a software development kit (SDK) designed to interact with and manipulate SpacetimeDB modules..",
   "keywords": [],
   "author": {


### PR DESCRIPTION
Updates package version to 1.0.1

## API

 - [ ] This is an API breaking change to the SDK

## Requires SpacetimeDB PRs
No specific PR needed

## Testsuite

SpacetimeDB branch name: release/v1.0.1

## Testing

- [X] Confirmed Unity sees version as 1.0.1 after change
