### PR TITLE
Bump versions to 1.1.0

### DIFF
--- a/SpacetimeDB.ClientSDK.csproj
+++ b/SpacetimeDB.ClientSDK.csproj
@@ -16,8 +16,8 @@
     <PackageIcon>logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk</RepositoryUrl>
-    <AssemblyVersion>1.0.1</AssemblyVersion>
-    <Version>1.0.1</Version>
+    <AssemblyVersion>1.1.0</AssemblyVersion>
+    <Version>1.1.0</Version>
     <DefaultItemExcludes>$(DefaultItemExcludes);*~/**</DefaultItemExcludes>
     <!-- We want to save DLLs for Unity which doesn't support NuGet. -->
     <RestorePackagesPath>packages</RestorePackagesPath>
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.BSATN.Runtime" Version="1.0.*" />
+    <PackageReference Include="SpacetimeDB.BSATN.Runtime" Version="1.1.*" />
 
     <InternalsVisibleTo Include="SpacetimeDB.Tests" />
   </ItemGroup>

--- a/examples~/quickstart-chat/server/StdbModule.csproj
+++ b/examples~/quickstart-chat/server/StdbModule.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Runtime" Version="1.0.0-rc4" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="1.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description of Changes
Bumped version numbers to 1.1.0.

## API

 - [ ] This is an API breaking change to the SDK

No, this just updates to the latest version.

## Requires SpacetimeDB PRs
https://github.com/clockworklabs/SpacetimeDB/pull/2518

## Testsuite
SpacetimeDB branch name: bfops/bump-version

## Testing
- [x] Existing CI passes (when pointed at the corresponding SpacetimeDB branch)