### PR TITLE
Fix row deduplication issues

### DIFF
--- a/src/MultiDictionary.cs
+++ b/src/MultiDictionary.cs
@@ -4,7 +4,6 @@ using System.Text;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Data;
-using System.Security.Cryptography.X509Certificates;
 
 namespace SpacetimeDB
 {

--- a/src/MultiDictionary.cs
+++ b/src/MultiDictionary.cs
@@ -490,7 +490,8 @@ namespace SpacetimeDB
                     var d2 = D2.Value;
                     Debug.Assert(equalityComparer.Equals(value, d2.Value));
                     // In release mode, the above assert won't fire.
-                    // This means that if we get conflicting updates, whichever one we saw first will win.
+                    // This means that if we get more than two values, the first two distinct values seen
+                    // will be the ones stored in the KeyDelta.
                     d2.Delta += 1;
                     D2 = d2;
                 }
@@ -517,7 +518,8 @@ namespace SpacetimeDB
                     var newD2 = D2.Value;
                     Debug.Assert(equalityComparer.Equals(value, newD2.Value));
                     // In release mode, the above assert won't fire.
-                    // This means that if we get conflicting updates, whichever one we saw first will win.
+                    // This means that if we get more than two values, the first two distinct values seen
+                    // will be the ones stored in the KeyDelta.
                     newD2.Delta -= 1;
                     D2 = newD2;
                 }
@@ -530,7 +532,7 @@ namespace SpacetimeDB
             /// If either is in an invalid state, this throws.
             /// That means you should avoid comparing KeyDeltas
             /// (and therefore MultiDictionaryDeltas) unless you are sure they are valid, i.e. until they have
-            /// absorbed all the necessary writes.
+            /// absorbed all the necessary Adds and Removes.
             /// </summary>
             /// <param name="other"></param>
             /// <param name="equalityComparer"></param>

--- a/src/MultiDictionary.cs
+++ b/src/MultiDictionary.cs
@@ -489,6 +489,8 @@ namespace SpacetimeDB
                 {
                     var d2 = D2.Value;
                     Debug.Assert(equalityComparer.Equals(value, d2.Value));
+                    // In release mode, the above assert won't fire.
+                    // This means that if we get conflicting updates, whichever one we saw first will win.
                     d2.Delta += 1;
                     D2 = d2;
                 }
@@ -514,6 +516,8 @@ namespace SpacetimeDB
                 {
                     var newD2 = D2.Value;
                     Debug.Assert(equalityComparer.Equals(value, newD2.Value));
+                    // In release mode, the above assert won't fire.
+                    // This means that if we get conflicting updates, whichever one we saw first will win.
                     newD2.Delta -= 1;
                     D2 = newD2;
                 }

--- a/tests~/MultiDictionaryTests.cs
+++ b/tests~/MultiDictionaryTests.cs
@@ -241,4 +241,25 @@ public class MultiDictionaryTests
         var wasRemoved = new List<KeyValuePair<object, byte>>();
         dict.Apply(delta, wasInserted, wasMaybeUpdated, wasRemoved);
     }
+
+    [Fact]
+    public void InsertThenDeleteOfOldRow()
+    {
+        var dict = new MultiDictionary<byte, byte>(EqualityComparer<byte>.Default, EqualityComparer<byte>.Default);
+        dict.Add(1, 2);
+
+        var delta = new MultiDictionaryDelta<byte, byte>(EqualityComparer<byte>.Default, EqualityComparer<byte>.Default);
+        delta.Add(1, 3);
+        delta.Add(1, 2);
+        delta.Remove(1, 2);
+        delta.Remove(1, 2);
+
+        var wasInserted = new List<KeyValuePair<byte, byte>>();
+        var wasMaybeUpdated = new List<(byte key, byte oldValue, byte newValue)>();
+        var wasRemoved = new List<KeyValuePair<byte, byte>>();
+        dict.Apply(delta, wasInserted, wasMaybeUpdated, wasRemoved);
+#pragma warning disable xUnit2017
+        Assert.True(wasMaybeUpdated.Contains((1, 2, 3)), $"{dict}: {wasMaybeUpdated}");
+#pragma warning restore xUnit2017
+    }
 }

--- a/tests~/MultiDictionaryTests.cs
+++ b/tests~/MultiDictionaryTests.cs
@@ -19,22 +19,35 @@ public class MultiDictionaryTests
     where TKey : notnull
     {
         return Gen.Select(g1, g2, (b1, b2) => new KeyValuePair<TKey, TValue>(b1, b2)).List[ListMinLength, ListMaxLength].Select(list =>
+            NormalizeDuplicates(list, equality)
+        );
+    }
+
+    /// <summary>
+    /// Normalize a list so that, if any two items have duplicate Keys, they have the same Value.
+    /// </summary>
+    /// <typeparam name="TKey"></typeparam>
+    /// <typeparam name="TValue"></typeparam>
+    /// <param name="list"></param>
+    /// <param name="equality"></param>
+    /// <returns></returns>
+    List<KeyValuePair<TKey, TValue>> NormalizeDuplicates<TKey, TValue>(List<KeyValuePair<TKey, TValue>> list, IEqualityComparer<TKey> equality)
+    where TKey : notnull
+    {
+        Dictionary<TKey, TValue> seenKeys = new(equality);
+        for (var i = 0; i < list.Count; i++)
         {
-            Dictionary<TKey, TValue> seenKeys = new(equality);
-            for (var i = 0; i < list.Count; i++)
+            var (b1, b2) = list[i];
+            if (seenKeys.ContainsKey(b1))
             {
-                var (b1, b2) = list[i];
-                if (seenKeys.ContainsKey(b1))
-                {
-                    list[i] = new(b1, seenKeys[b1]);
-                }
-                else
-                {
-                    seenKeys[b1] = b2;
-                }
+                list[i] = new(b1, seenKeys[b1]);
             }
-            return list;
-        });
+            else
+            {
+                seenKeys[b1] = b2;
+            }
+        }
+        return list;
     }
 
     [Fact]
@@ -153,8 +166,11 @@ public class MultiDictionaryTests
         Gen.Select(ListWithRemovals(Gen.Byte[1, 10], Gen.Byte[1, 10], EqualityComparer<byte>.Default, maxLength), Gen.Int[0, 32].List[0, 5]).Sample((listRemovals, cuts) =>
         {
             // Test that building up a MultiDictionary an operation-at-a-time is the same as randomly grouping the operations and applying them in chunks using MultiDictionaryDeltas.
+            // Pre-normalizes the list of operations so that the same key is always associated with the same value.
+
             // Note: When looking at test failures for this test, keep in mind we do some post-processing of the sample input data.
-            // So the listed `removals` and `cuts` may be changed slightly during the test.
+            // So the listed operations may be changed slightly while the test is executing.
+            // CsCheck doesn't give us a good way to log this :/
             var (list, removals) = listRemovals;
             cuts.Add(0);
             cuts.Add(maxLength);
@@ -172,8 +188,6 @@ public class MultiDictionaryTests
             foreach (var (start, end) in cuts.Zip(cuts.Skip(1)))
             {
                 var delta = new MultiDictionaryDelta<byte, byte>(EqualityComparer<byte>.Default, EqualityComparer<byte>.Default);
-
-                var (start_, end_) = (int.Min(start, list.Count), int.Min(end, list.Count));
 
                 foreach (var (item, remove) in list[start..end].Zip(removals[start..end]))
                 {
@@ -207,6 +221,115 @@ public class MultiDictionaryTests
                 foreach (var (key, oldValue, newValue) in wasMaybeUpdated)
                 {
                     Assert.True(viaChunkDeltas.Contains(new(key, newValue)) && oldValue == newValue);
+                }
+                foreach (var (key, value) in wasRemoved)
+                {
+                    Assert.False(viaChunkDeltas.Contains(new(key, value)));
+                }
+                Assert.Equal(viaAddRemove, viaChunkDeltas);
+            }
+        }, iter: 10_000);
+    }
+
+    [Fact]
+    public void ChunkedRemovalsWithValueChanges()
+    {
+        // Test that building up a MultiDictionary an operation-at-a-time is the same as randomly grouping the operations and applying them in chunks using MultiDictionaryDeltas.
+        // Unlike ChunkedRemovals, this doesn't pre-normalize the list of operations so that the same key always has the same value.
+        // Instead, in a particular chunk of operations, if a new value is assigned to a key, we go in and remove the old value the correct number of times.
+
+        var maxLength = 32;
+        // Don't pre-normalize the list.
+        // We want to normalize per-chunk instead.
+        var listRemovalsNonNormalized = Gen.SelectMany(
+            Gen.Int[0, maxLength], (listLength) => Gen.Select(
+                // the data itself
+                Gen.Select(Gen.Byte[1, 10], Gen.Byte[1, 10], (b1, b2) => new KeyValuePair<byte, byte>(b1, b2)).List[listLength, listLength],
+                // whether this element should be added or removed
+                Gen.Bool.List[listLength]
+            ));
+
+        Gen.Select(listRemovalsNonNormalized, Gen.Int[0, maxLength].List[0, 5]).Select((listRemovals, cuts) =>
+        {
+            var (list, removals) = listRemovals;
+
+            cuts.Add(0);
+            cuts.Add(maxLength);
+            cuts = cuts.Select(cut => int.Min(cut, list.Count)).ToList();
+            cuts.Sort();
+
+            var listWithRemovals = list.Zip(removals).ToList();
+
+            var equalityComparer = EqualityComparer<byte>.Default;
+
+            var viaAddRemove = new MultiDictionary<byte, byte>(equalityComparer, equalityComparer);
+
+            return cuts.Zip(cuts.Skip(1)).Select((range) =>
+            {
+                var (start, end) = range;
+                var listChunk = list[start..end];
+                NormalizeDuplicates(listChunk, equalityComparer);
+                var removalsChunk = removals[start..end];
+
+                return (listChunk, removalsChunk);
+            }).ToList();
+        })
+        .Sample((chunkedListRemovals) =>
+        {
+            var equalityComparer = EqualityComparer<byte>.Default;
+
+            var viaAddRemove = new MultiDictionary<byte, byte>(equalityComparer, equalityComparer);
+            var viaChunkDeltas = new MultiDictionary<byte, byte>(equalityComparer, equalityComparer);
+
+            foreach (var (listChunk, removalsChunk) in chunkedListRemovals)
+            {
+                var delta = new MultiDictionaryDelta<byte, byte>(equalityComparer, equalityComparer);
+
+                foreach (var (item, remove) in listChunk.Zip(removalsChunk))
+                {
+                    if (viaAddRemove.Multiplicity(item.Key) > 0 && !equalityComparer.Equals(viaAddRemove[item.Key], item.Value))
+                    {
+                        var oldValue = viaAddRemove[item.Key];
+                        // This chunk is going to change the value associated with this key.
+                        // Remove it the correct number of times.
+                        var mult = viaAddRemove.Multiplicity(item.Key);
+                        for (uint i = 0; i < mult; i++)
+                        {
+                            viaAddRemove.Remove(item.Key, out var _);
+                            delta.Remove(item.Key, oldValue);
+                        }
+                    }
+
+                    // it's an error to remove-too-many-times with the Delta api.
+                    // so, don't remove anything we don't have.
+                    var remove_ = remove && viaAddRemove.Contains(item);
+                    if (remove_)
+                    {
+                        viaAddRemove.Remove(item.Key, out var _);
+                        delta.Remove(item.Key, item.Value);
+                    }
+                    else
+                    {
+                        viaAddRemove.Add(item.Key, item.Value);
+                        delta.Add(item.Key, item.Value);
+                    }
+                }
+                foreach (var (key, value) in viaChunkDeltas.WillRemove(delta))
+                {
+                    Assert.True(viaChunkDeltas.Contains(new(key, value)));
+                }
+                var wasInserted = new List<KeyValuePair<byte, byte>>();
+                var wasMaybeUpdated = new List<(byte key, byte oldValue, byte newValue)>();
+                var wasRemoved = new List<KeyValuePair<byte, byte>>();
+
+                viaChunkDeltas.Apply(delta, wasInserted, wasMaybeUpdated, wasRemoved);
+                foreach (var (key, value) in wasInserted)
+                {
+                    Assert.True(viaChunkDeltas.Contains(new(key, value)));
+                }
+                foreach (var (key, oldValue, newValue) in wasMaybeUpdated)
+                {
+                    Assert.True(viaChunkDeltas.Contains(new(key, newValue)));
                 }
                 foreach (var (key, value) in wasRemoved)
                 {
@@ -257,6 +380,25 @@ public class MultiDictionaryTests
         var wasInserted = new List<KeyValuePair<byte, byte>>();
         var wasMaybeUpdated = new List<(byte key, byte oldValue, byte newValue)>();
         var wasRemoved = new List<KeyValuePair<byte, byte>>();
+        dict.Apply(delta, wasInserted, wasMaybeUpdated, wasRemoved);
+#pragma warning disable xUnit2017
+        Assert.True(wasMaybeUpdated.Contains((1, 2, 3)), $"{dict}: {wasMaybeUpdated}");
+#pragma warning restore xUnit2017
+
+        // And one more permutation.
+
+        dict = new MultiDictionary<byte, byte>(EqualityComparer<byte>.Default, EqualityComparer<byte>.Default);
+        dict.Add(1, 2);
+
+        delta = new MultiDictionaryDelta<byte, byte>(EqualityComparer<byte>.Default, EqualityComparer<byte>.Default);
+        delta.Add(1, 3);
+        delta.Remove(1, 2);
+        delta.Remove(1, 2);
+        delta.Add(1, 2);
+
+        wasInserted = new List<KeyValuePair<byte, byte>>();
+        wasMaybeUpdated = new List<(byte key, byte oldValue, byte newValue)>();
+        wasRemoved = new List<KeyValuePair<byte, byte>>();
         dict.Apply(delta, wasInserted, wasMaybeUpdated, wasRemoved);
 #pragma warning disable xUnit2017
         Assert.True(wasMaybeUpdated.Contains((1, 2, 3)), $"{dict}: {wasMaybeUpdated}");

--- a/tests~/MultiDictionaryTests.cs
+++ b/tests~/MultiDictionaryTests.cs
@@ -249,8 +249,8 @@ public class MultiDictionaryTests
         dict.Add(1, 2);
 
         var delta = new MultiDictionaryDelta<byte, byte>(EqualityComparer<byte>.Default, EqualityComparer<byte>.Default);
-        delta.Add(1, 3);
         delta.Add(1, 2);
+        delta.Add(1, 3);
         delta.Remove(1, 2);
         delta.Remove(1, 2);
 


### PR DESCRIPTION
## Description of Changes
Addresses https://github.com/clockworklabs/SpacetimeDBPrivate/issues/1585

There was an issue with row deduplication when a TransactionUpdate of the form:

```
+ k1: v1
- k1: v1
- k1: v1
+ k1: v2
```
appeared, where `k1` is the primary key of a row and `v1`, `v2` are the full values of that row. The old manner of processing updates would see this as a no-op. I've updated the logic to handle this case correctly, at the cost of an extra equality comparison per row in an update. (Actually it's slightly cheaper than this, it skips the equality comparison if there is only row with a particular primary key in an update. This may help speed up processing of large updates e.g. chunk data in BitCraft.)

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*

## Requires SpacetimeDB PRs

## Testsuite

SpacetimeDB branch name: master

## Testing

- [x] Added a failing test, then fixed it