### PR TITLE
Bump versions to 1.1.1

### DIFF
--- a/SpacetimeDB.ClientSDK.csproj
+++ b/SpacetimeDB.ClientSDK.csproj
@@ -16,8 +16,8 @@
     <PackageIcon>logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk</RepositoryUrl>
-    <AssemblyVersion>1.1.0</AssemblyVersion>
-    <Version>1.1.0</Version>
+    <AssemblyVersion>1.1.1</AssemblyVersion>
+    <Version>1.1.1</Version>
     <DefaultItemExcludes>$(DefaultItemExcludes);*~/**</DefaultItemExcludes>
     <!-- We want to save DLLs for Unity which doesn't support NuGet. -->
     <RestorePackagesPath>packages</RestorePackagesPath>

--- a/examples~/quickstart-chat/server/StdbModule.csproj
+++ b/examples~/quickstart-chat/server/StdbModule.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Runtime" Version="1.1.0" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="1.1.*" />
   </ItemGroup>
 
 </Project>

--- a/examples~/regression-tests/server/StdbModule.csproj
+++ b/examples~/regression-tests/server/StdbModule.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Runtime" Version="1.1.0" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="1.1.*" />
   </ItemGroup>
 
 </Project>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.clockworklabs.spacetimedbsdk",
   "displayName": "SpacetimeDB SDK",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "The SpacetimeDB Client SDK is a software development kit (SDK) designed to interact with and manipulate SpacetimeDB modules..",
   "keywords": [],
   "author": {


### PR DESCRIPTION
## Description of Changes
Just bumping version numbers in preparation for an upcoming release.

I also relaxed the version constraints in the `.csproj` files to be flexible in their patch versions.

## API

 - [ ] This is an API breaking change to the SDK

No breaking changes.

## Requires SpacetimeDB PRs
None

## Testsuite
SpacetimeDB branch name: master

## Testing
Just existing CI, since this just bumps version numbers.