### PR TITLE
CI - Release branch check auto-changes base branch

### DIFF
--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -21,13 +21,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          repo_full_name="${{ github.repository }}"
-          echo 'Updating PR '"#$pr_number"' to use base `master`'
+          echo 'Updating PR '"#${{ github.event.pull_request.number }}"' to use base `master`'
           echo 'If you do want to release your changes directly by merging into `release/latest`, your branch must start with `release/`.'
 
           curl -X PATCH \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/$repo_full_name/pulls/$pr_number \
+            https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} \
             -d '{"base": "master"}'

--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -13,10 +13,12 @@ jobs:
     name: Release branch restriction
     runs-on: ubuntu-latest
     steps:
-      - name: Set up GitHub CLI
-        uses: cli/cli-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install GitHub CLI
+        run: |
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+          sudo apt-add-repository https://cli.github.com/packages
+          sudo apt-get update
+          sudo apt-get install gh -y
 
       - name: Auto-change base to master if needed
         if: |

--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -13,22 +13,20 @@ jobs:
     name: Release branch restriction
     runs-on: ubuntu-latest
     steps:
-      - name: Install GitHub CLI
-        run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-          sudo apt-add-repository https://cli.github.com/packages
-          sudo apt-get update
-          sudo apt-get install gh -y
-
       - name: Auto-change base to master if needed
         if: |
           github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'release/latest' &&
           ! startsWith(github.event.pull_request.head.ref, 'release/')
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          pr_number="${{ github.event.pull_request.number }}"
-          echo 'Changing base branch of PR '"#$pr_number"' to `master`...'
-          echo 'If you wanted to merge into `release/latest`, make sure your branch starts with `release/`'
-          gh pr edit "$pr_number" --base master
+          pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          repo_full_name="${{ github.repository }}"
+          echo "Updating PR #$pr_number to use base 'master'"
+
+          curl -X PATCH \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/$repo_full_name/pulls/$pr_number \
+            -d '{"base": "master"}'

--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -13,7 +13,7 @@ jobs:
     name: Release branch restriction
     runs-on: ubuntu-latest
     steps:
-      - name: Auto-change base to master if needed
+      - name: Change base to master if needed
         if: |
           github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'release/latest' &&
@@ -23,7 +23,8 @@ jobs:
         run: |
           pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
           repo_full_name="${{ github.repository }}"
-          echo "Updating PR #$pr_number to use base 'master'"
+          echo 'Updating PR '"#$pr_number"' to use base `master`'
+          echo 'If you do want to release your changes directly by merging into `release/latest`, your branch must start with `release/`.'
 
           curl -X PATCH \
             -H "Authorization: Bearer $GITHUB_TOKEN" \

--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -3,20 +3,30 @@ name: Git tree checks
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
-  merge_group:
-permissions: read-all
+
+permissions:
+  pull-requests: write
+  contents: read
 
 jobs:
   check_base_ref:
     name: Release branch restriction
     runs-on: ubuntu-latest
     steps:
-      - id: not_based_on_master
+      - name: Set up GitHub CLI
+        uses: cli/cli-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-change base to master if needed
         if: |
           github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref == 'release/latest' &&
           ! startsWith(github.event.pull_request.head.ref, 'release/')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo 'Only `release/*` branches are allowed to merge into the release branch `release/latest`.'
-          echo 'Maybe you want to change your PR base to `master`?'
-          exit 1
+          pr_number="${{ github.event.pull_request.number }}"
+          echo 'Changing base branch of PR '"#$pr_number"' to `master`...'
+          echo 'If you wanted to merge into `release/latest`, make sure your branch starts with `release/`'
+          gh pr edit "$pr_number" --base master


### PR DESCRIPTION
## Description of Changes
Instead of our CI failing and telling the user that a PR should be based on `master`, we automatically change the base branch to `master`.

## API

No code changes.

## Requires SpacetimeDB PRs
None

## Testsuite
SpacetimeDB branch name: master

## Testing
- [x] See below, where the new CI changed the base branch of this PR!
- [x] On this test PR, the base branch was not changed: https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/pull/299