### PR TITLE
Significantly reduce small byte array allocations

### DIFF
--- a/src/BSATNHelpers.cs
+++ b/src/BSATNHelpers.cs
@@ -5,9 +5,27 @@ namespace SpacetimeDB
 {
     public static class BSATNHelpers
     {
+        /// <summary>
+        /// Decode an element of a BSATN-serializable type from a list of bytes.
+        ///
+        /// This method performs several allocations. Prefer calling <c>IStructuralReadWrite.Read<T>(BinaryReader)</c> when
+        /// deserializing many items from a buffer.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="bsatn"></param>
+        /// <returns></returns>
         public static T Decode<T>(System.Collections.Generic.List<byte> bsatn) where T : IStructuralReadWrite, new() =>
             Decode<T>(bsatn.ToArray());
 
+        /// <summary>
+        /// Decode an element of a BSATN-serializable type from a byte array.
+        ///
+        /// This method performs several allocations. Prefer calling <c>IStructuralReadWrite.Read<T>(BinaryReader)</c> when
+        /// deserializing many items from a buffer.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="bsatn"></param>
+        /// <returns></returns>
         public static T Decode<T>(byte[] bsatn) where T : IStructuralReadWrite, new()
         {
             using var stream = new MemoryStream(bsatn);

--- a/src/ListStream.cs
+++ b/src/ListStream.cs
@@ -6,7 +6,7 @@ using SpacetimeDB;
 /// <summary>
 /// A stream that reads from an underlying list.
 /// 
-/// Uses two less allocation than converting to a byte array and building a MemoryStream.
+/// Uses one less allocation than converting to a byte array and building a MemoryStream.
 /// </summary>
 internal class ListStream : Stream
 {

--- a/src/ListStream.cs
+++ b/src/ListStream.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+/// <summary>
+/// A stream that reads from an underlying list.
+/// 
+/// Uses one less allocation than converting to a byte array and building a MemoryStream.
+/// </summary>
+internal class ListStream : Stream
+{
+    private List<byte> list;
+    private int pos;
+
+    public ListStream(List<byte> data)
+    {
+        this.list = data;
+        this.pos = 0;
+    }
+
+    public override bool CanRead => true;
+
+    public override bool CanSeek => true;
+
+    public override bool CanWrite => false;
+
+    public override long Length => list.Count;
+
+    public override long Position { get => pos; set => pos = (int)value; }
+
+    public override void Flush()
+    {
+        // do nothing
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        int listPos = pos;
+        int listLength = list.Count;
+        int bufPos = offset;
+        int bufLength = buffer.Length;
+        for (; listPos < listLength && bufPos < bufLength; listPos++, bufPos++)
+        {
+            buffer[bufPos] = list[listPos];
+        }
+        pos = listPos;
+        return bufPos - offset;
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        int listPos = pos;
+        int listLength = list.Count;
+        int bufPos = 0;
+        int bufLength = buffer.Length;
+        for (; listPos < listLength && bufPos < bufLength; listPos++, bufPos++)
+        {
+            buffer[bufPos] = list[listPos];
+        }
+        pos = listPos;
+        return bufPos;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        switch (origin)
+        {
+            case SeekOrigin.Begin:
+                pos = (int)offset;
+                break;
+            case SeekOrigin.Current:
+                pos += (int)offset;
+                break;
+            case SeekOrigin.End:
+                pos = (int)(Length + offset);
+                break;
+        }
+        return pos;
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new System.NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        throw new System.NotSupportedException();
+    }
+}

--- a/src/ListStream.cs
+++ b/src/ListStream.cs
@@ -37,10 +37,10 @@ internal class ListStream : Stream
     public override int Read(byte[] buffer, int offset, int count)
     {
         int listPos = pos;
-        int listLength = Math.Min(list.Count, listPos + count);
+        int listEnd = Math.Min(list.Count, listPos + count);
         int bufPos = offset;
         int bufLength = buffer.Length;
-        for (; listPos < listLength && bufPos < bufLength; listPos++, bufPos++)
+        for (; listPos < listEnd && bufPos < bufLength; listPos++, bufPos++)
         {
             buffer[bufPos] = list[listPos];
         }

--- a/src/ListStream.cs
+++ b/src/ListStream.cs
@@ -5,7 +5,7 @@ using System.IO;
 /// <summary>
 /// A stream that reads from an underlying list.
 /// 
-/// Uses one less allocation than converting to a byte array and building a MemoryStream.
+/// Uses two less allocation than converting to a byte array and building a MemoryStream.
 /// </summary>
 internal class ListStream : Stream
 {

--- a/src/ListStream.cs
+++ b/src/ListStream.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using SpacetimeDB;
 
 /// <summary>
 /// A stream that reads from an underlying list.
@@ -36,7 +37,7 @@ internal class ListStream : Stream
     public override int Read(byte[] buffer, int offset, int count)
     {
         int listPos = pos;
-        int listLength = list.Count;
+        int listLength = Math.Min(list.Count, listPos + count);
         int bufPos = offset;
         int bufLength = buffer.Length;
         for (; listPos < listLength && bufPos < bufLength; listPos++, bufPos++)

--- a/src/ListStream.cs.meta
+++ b/src/ListStream.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7877850cecd6e3649a8a315c438f443d

--- a/src/ListStream.cs.meta
+++ b/src/ListStream.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 7877850cecd6e3649a8a315c438f443d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -211,11 +211,10 @@ namespace SpacetimeDB
 
         struct ProcessedDatabaseUpdate
         {
-            // Map: table handles -> (primary key -> DbValue).
-            // If a particular table has no primary key, the "primary key" is just a byte[]
-            // storing the BSATN encoding of the row.
-            // See Decode(...).
-            public Dictionary<IRemoteTableHandle, MultiDictionaryDelta<object, DbValue>> Updates;
+            // Map: table handles -> (primary key -> IStructuralReadWrite).
+            // If a particular table has no primary key, the "primary key" is just the row itself.
+            // This is valid because any [SpacetimeDB.Type] automatically has a correct Equals and HashSet implementation.
+            public Dictionary<IRemoteTableHandle, MultiDictionaryDelta<object, IStructuralReadWrite>> Updates;
 
             // Can't override the default constructor. Make sure you use this one!
             public static ProcessedDatabaseUpdate New()
@@ -225,13 +224,13 @@ namespace SpacetimeDB
                 return result;
             }
 
-            public MultiDictionaryDelta<object, DbValue> DeltaForTable(IRemoteTableHandle table)
+            public MultiDictionaryDelta<object, IStructuralReadWrite> DeltaForTable(IRemoteTableHandle table)
             {
                 if (!Updates.TryGetValue(table, out var delta))
                 {
                     // Make sure we use GenericEqualityComparer here, since it handles byte[]s and arbitrary primary key types
                     // correctly.
-                    delta = new MultiDictionaryDelta<object, DbValue>(GenericEqualityComparer.Instance, DbValueComparer.Instance);
+                    delta = new MultiDictionaryDelta<object, IStructuralReadWrite>(GenericEqualityComparer.Instance, GenericEqualityComparer.Instance);
                     Updates[table] = delta;
                 }
 
@@ -268,15 +267,17 @@ namespace SpacetimeDB
         /// <param name="bin"></param>
         /// <param name="primaryKey"></param>
         /// <returns></returns>
-        static DbValue Decode(IRemoteTableHandle table, byte[] bin, out object primaryKey)
+        static IStructuralReadWrite Decode(IRemoteTableHandle table, BinaryReader reader, out object primaryKey)
         {
-            var obj = table.DecodeValue(bin);
+            var obj = table.DecodeValue(reader);
+
             // TODO(1.1): we should exhaustively check that GenericEqualityComparer works
             // for all types that are allowed to be primary keys.
             var primaryKey_ = table.GetPrimaryKey(obj);
-            primaryKey_ ??= bin;
+            primaryKey_ ??= obj;
             primaryKey = primaryKey_;
-            return new(obj, bin);
+
+            return obj;
         }
 
         private static readonly Status Committed = new Status.Committed(default);
@@ -353,24 +354,28 @@ namespace SpacetimeDB
             return new QueryUpdate.BSATN().Read(new BinaryReader(memoryStream));
         }
 
-        private static IEnumerable<byte[]> BsatnRowListIter(BsatnRowList list)
-        {
-            var rowsData = list.RowsData;
 
-            return list.SizeHint switch
-            {
-                RowSizeHint.FixedSize(var size) => Enumerable
-                    .Range(0, rowsData.Count / size)
-                    .Select(index => rowsData.Skip(index * size).Take(size).ToArray()),
-
-                RowSizeHint.RowOffsets(var offsets) => offsets.Zip(
-                    offsets.Skip(1).Append((ulong)rowsData.Count),
-                    (start, end) => rowsData.Take((int)end).Skip((int)start).ToArray()
-                ),
-
-                _ => throw new InvalidOperationException("Unknown RowSizeHint variant"),
-            };
-        }
+        /// <summary>
+        /// Prepare to read a BsatnRowList.
+        /// 
+        /// This could return an IEnumerable, but we return the reader and row count directly to avoid an allocation.
+        /// It is legitimate to repeatedly call <c>IStructuralReadWrite.Read<T></c> <c>rowCount</c> times on the resulting
+        /// BinaryReader:
+        /// Our decoding infrastructure guarantees that reading a value consumes the correct number of bytes
+        /// from the BinaryReader. (This is easy because BSATN doesn't have padding.)
+        /// </summary>
+        /// <param name="list"></param>
+        /// <returns>A reader for the rows of the list and a count of rows.</returns>
+        private static (BinaryReader reader, int rowCount) ParseRowList(BsatnRowList list) =>
+            (
+                new BinaryReader(new ListStream(list.RowsData)),
+                list.SizeHint switch
+                {
+                    RowSizeHint.FixedSize(var size) => list.RowsData.Count / size,
+                    RowSizeHint.RowOffsets(var offsets) => offsets.Count,
+                    _ => throw new NotImplementedException()
+                }
+            );
 
 #if UNITY_WEBGL && !UNITY_EDITOR
         IEnumerator PreProcessMessages()
@@ -455,9 +460,10 @@ namespace SpacetimeDB
                     {
                         Log.Warn("Non-insert during an insert-only server message!");
                     }
-                    foreach (var bin in BsatnRowListIter(qu.Inserts))
+                    var (insertReader, insertRowCount) = ParseRowList(qu.Inserts);
+                    for (var i = 0; i < insertRowCount; i++)
                     {
-                        var obj = Decode(table, bin, out var pk);
+                        var obj = Decode(table, insertReader, out var pk);
                         delta.Add(pk, obj);
                     }
                 }
@@ -473,9 +479,11 @@ namespace SpacetimeDB
                     {
                         Log.Warn("Non-delete during a delete-only operation!");
                     }
-                    foreach (var bin in BsatnRowListIter(qu.Deletes))
+
+                    var (deleteReader, deleteRowCount) = ParseRowList(qu.Deletes);
+                    for (var i = 0; i < deleteRowCount; i++)
                     {
-                        var obj = Decode(table, bin, out var pk);
+                        var obj = Decode(table, deleteReader, out var pk);
                         delta.Remove(pk, obj);
                     }
                 }
@@ -491,14 +499,17 @@ namespace SpacetimeDB
                     // Because we are accumulating into a MultiDictionaryDelta that will be applied all-at-once
                     // to the table, it doesn't matter that we call Add before Remove here.
 
-                    foreach (var bin in BsatnRowListIter(qu.Inserts))
+                    var (insertReader, insertRowCount) = ParseRowList(qu.Inserts);
+                    for (var i = 0; i < insertRowCount; i++)
                     {
-                        var obj = Decode(table, bin, out var pk);
+                        var obj = Decode(table, insertReader, out var pk);
                         delta.Add(pk, obj);
                     }
-                    foreach (var bin in BsatnRowListIter(qu.Deletes))
+
+                    var (deleteReader, deleteRowCount) = ParseRowList(qu.Deletes);
+                    for (var i = 0; i < deleteRowCount; i++)
                     {
-                        var obj = Decode(table, bin, out var pk);
+                        var obj = Decode(table, deleteReader, out var pk);
                         delta.Remove(pk, obj);
                     }
                 }
@@ -1002,9 +1013,13 @@ namespace SpacetimeDB
                 return LogAndThrow($"Mismatched result type, expected {typeof(T)} but got {resultTable.TableName}");
             }
 
-            return BsatnRowListIter(resultTable.Rows)
-                .Select(BSATNHelpers.Decode<T>)
-                .ToArray();
+            var (resultReader, resultCount) = ParseRowList(resultTable.Rows);
+            var output = new T[resultCount];
+            for (int i = 0; i < resultCount; i++)
+            {
+                output[i] = IStructuralReadWrite.Read<T>(resultReader);
+            }
+            return output;
         }
 
         public bool IsActive => webSocket.IsConnected;
@@ -1055,33 +1070,5 @@ namespace SpacetimeDB
             lastAllocated++;
             return lastAllocated;
         }
-    }
-    internal readonly struct DbValue
-    {
-        public readonly IStructuralReadWrite value;
-        public readonly byte[] bytes;
-
-        public DbValue(IStructuralReadWrite value, byte[] bytes)
-        {
-            this.value = value;
-            this.bytes = bytes;
-        }
-
-        // TODO: having a nice ToString here would give better way better errors when applying table deltas,
-        // but it's tricky to do that generically.
-    }
-
-    /// <summary>
-    /// DbValue comparer that uses BSATN-encoded records to compare DbValues for equality.
-    /// </summary>
-    internal readonly struct DbValueComparer : IEqualityComparer<DbValue>
-    {
-        public static DbValueComparer Instance = new();
-
-        public bool Equals(DbValue x, DbValue y) =>
-            ByteArrayComparer.Instance.Equals(x.bytes, y.bytes);
-
-        public int GetHashCode(DbValue obj) =>
-            ByteArrayComparer.Instance.GetHashCode(obj.bytes);
     }
 }

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -11,6 +11,7 @@ using SpacetimeDB.BSATN;
 using SpacetimeDB.Internal;
 using SpacetimeDB.ClientApi;
 using Thread = System.Threading.Thread;
+using System.Diagnostics;
 
 
 namespace SpacetimeDB

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -228,9 +228,7 @@ namespace SpacetimeDB
             {
                 if (!Updates.TryGetValue(table, out var delta))
                 {
-                    // Make sure we use GenericEqualityComparer here, since it handles byte[]s and arbitrary primary key types
-                    // correctly.
-                    delta = new MultiDictionaryDelta<object, IStructuralReadWrite>(GenericEqualityComparer.Instance, GenericEqualityComparer.Instance);
+                    delta = new MultiDictionaryDelta<object, IStructuralReadWrite>(EqualityComparer<object>.Default, EqualityComparer<object>.Default);
                     Updates[table] = delta;
                 }
 

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -264,7 +264,7 @@ namespace SpacetimeDB
         /// If not, the BSATN for the entire row is used instead.
         /// </summary>
         /// <param name="table"></param>
-        /// <param name="bin"></param>
+        /// <param name="reader"></param>
         /// <param name="primaryKey"></param>
         /// <returns></returns>
         static IStructuralReadWrite Decode(IRemoteTableHandle table, BinaryReader reader, out object primaryKey)

--- a/src/Table.cs
+++ b/src/Table.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using SpacetimeDB.BSATN;
+using SpacetimeDB.ClientApi;
 
 namespace SpacetimeDB
 {
@@ -23,14 +25,14 @@ namespace SpacetimeDB
         internal string RemoteTableName { get; }
 
         internal Type ClientTableType { get; }
-        internal IStructuralReadWrite DecodeValue(byte[] bytes);
+        internal IStructuralReadWrite DecodeValue(BinaryReader reader);
 
         /// <summary>
         /// Start applying a delta to the table.
         /// This is called for all tables before any updates are actually applied, allowing OnBeforeDelete to be invoked correctly.
         /// </summary>
         /// <param name="multiDictionaryDelta"></param>
-        internal void PreApply(IEventContext context, MultiDictionaryDelta<object, DbValue> multiDictionaryDelta);
+        internal void PreApply(IEventContext context, MultiDictionaryDelta<object, IStructuralReadWrite> multiDictionaryDelta);
 
         /// <summary>
         /// Apply a delta to the table.
@@ -38,7 +40,7 @@ namespace SpacetimeDB
         /// Should fix up indices, to be ready for PostApply.
         /// </summary>
         /// <param name="multiDictionaryDelta"></param>
-        internal void Apply(IEventContext context, MultiDictionaryDelta<object, DbValue> multiDictionaryDelta);
+        internal void Apply(IEventContext context, MultiDictionaryDelta<object, IStructuralReadWrite> multiDictionaryDelta);
 
         /// <summary>
         /// Finish applying a delta to a table.
@@ -138,10 +140,10 @@ namespace SpacetimeDB
         // We store the BSATN encodings of objects next to their runtime representation.
         // This is memory-inefficient, but allows us to quickly compare objects when seeing if an update is a "real"
         // update or just a multiplicity change.
-        private readonly MultiDictionary<object, DbValue> Entries = new(GenericEqualityComparer.Instance, DbValueComparer.Instance);
+        private readonly MultiDictionary<object, IStructuralReadWrite> Entries = new(GenericEqualityComparer.Instance, GenericEqualityComparer.Instance);
 
         // The function to use for decoding a type value.
-        IStructuralReadWrite IRemoteTableHandle.DecodeValue(byte[] bytes) => BSATNHelpers.Decode<Row>(bytes);
+        IStructuralReadWrite IRemoteTableHandle.DecodeValue(BinaryReader reader) => IStructuralReadWrite.Read<Row>(reader);
 
         public delegate void RowEventHandler(EventContext context, Row row);
         public event RowEventHandler? OnInsert;
@@ -153,7 +155,7 @@ namespace SpacetimeDB
 
         public int Count => (int)Entries.CountDistinct;
 
-        public IEnumerable<Row> Iter() => Entries.Entries.Select(entry => (Row)entry.Value.value);
+        public IEnumerable<Row> Iter() => Entries.Entries.Select(entry => (Row)entry.Value);
 
         public Task<Row[]> RemoteQuery(string query) =>
             conn.RemoteQuery<Row>($"SELECT {RemoteTableName}.* FROM {RemoteTableName} {query}");
@@ -206,21 +208,21 @@ namespace SpacetimeDB
             }
         }
 
-        List<KeyValuePair<object, DbValue>> wasInserted = new();
-        List<(object key, DbValue oldValue, DbValue newValue)> wasUpdated = new();
-        List<KeyValuePair<object, DbValue>> wasRemoved = new();
+        List<KeyValuePair<object, IStructuralReadWrite>> wasInserted = new();
+        List<(object key, IStructuralReadWrite oldValue, IStructuralReadWrite newValue)> wasUpdated = new();
+        List<KeyValuePair<object, IStructuralReadWrite>> wasRemoved = new();
 
-        void IRemoteTableHandle.PreApply(IEventContext context, MultiDictionaryDelta<object, DbValue> multiDictionaryDelta)
+        void IRemoteTableHandle.PreApply(IEventContext context, MultiDictionaryDelta<object, IStructuralReadWrite> multiDictionaryDelta)
         {
             Debug.Assert(wasInserted.Count == 0 && wasUpdated.Count == 0 && wasRemoved.Count == 0, "Call Apply and PostApply before calling PreApply again");
 
             foreach (var (_, value) in Entries.WillRemove(multiDictionaryDelta))
             {
-                InvokeBeforeDelete(context, value.value);
+                InvokeBeforeDelete(context, value);
             }
         }
 
-        void IRemoteTableHandle.Apply(IEventContext context, MultiDictionaryDelta<object, DbValue> multiDictionaryDelta)
+        void IRemoteTableHandle.Apply(IEventContext context, MultiDictionaryDelta<object, IStructuralReadWrite> multiDictionaryDelta)
         {
             try
             {
@@ -241,40 +243,40 @@ namespace SpacetimeDB
             // (And we need to do it before any PostApply is called.)
             foreach (var (_, value) in wasInserted)
             {
-                if (value.value is Row newRow)
+                if (value is Row newRow)
                 {
                     OnInternalInsert?.Invoke(newRow);
                 }
                 else
                 {
-                    throw new Exception($"Invalid row type for table {RemoteTableName}: {value.value.GetType().Name}");
+                    throw new Exception($"Invalid row type for table {RemoteTableName}: {value.GetType().Name}");
                 }
             }
             foreach (var (_, oldValue, newValue) in wasUpdated)
             {
-                if (oldValue.value is Row oldRow)
+                if (oldValue is Row oldRow)
                 {
-                    OnInternalDelete?.Invoke((Row)oldValue.value);
+                    OnInternalDelete?.Invoke((Row)oldValue);
                 }
                 else
                 {
-                    throw new Exception($"Invalid row type for table {RemoteTableName}: {oldValue.value.GetType().Name}");
+                    throw new Exception($"Invalid row type for table {RemoteTableName}: {oldValue.GetType().Name}");
                 }
 
 
-                if (newValue.value is Row newRow)
+                if (newValue is Row newRow)
                 {
                     OnInternalInsert?.Invoke(newRow);
                 }
                 else
                 {
-                    throw new Exception($"Invalid row type for table {RemoteTableName}: {newValue.value.GetType().Name}");
+                    throw new Exception($"Invalid row type for table {RemoteTableName}: {newValue.GetType().Name}");
                 }
             }
 
             foreach (var (_, value) in wasRemoved)
             {
-                if (value.value is Row oldRow)
+                if (value is Row oldRow)
                 {
                     OnInternalDelete?.Invoke(oldRow);
                 }
@@ -285,15 +287,15 @@ namespace SpacetimeDB
         {
             foreach (var (_, value) in wasInserted)
             {
-                InvokeInsert(context, value.value);
+                InvokeInsert(context, value);
             }
             foreach (var (_, oldValue, newValue) in wasUpdated)
             {
-                InvokeUpdate(context, oldValue.value, newValue.value);
+                InvokeUpdate(context, oldValue, newValue);
             }
             foreach (var (_, value) in wasRemoved)
             {
-                InvokeDelete(context, value.value);
+                InvokeDelete(context, value);
             }
             wasInserted.Clear();
             wasUpdated.Clear();

--- a/src/Table.cs
+++ b/src/Table.cs
@@ -140,7 +140,7 @@ namespace SpacetimeDB
         // We store the BSATN encodings of objects next to their runtime representation.
         // This is memory-inefficient, but allows us to quickly compare objects when seeing if an update is a "real"
         // update or just a multiplicity change.
-        private readonly MultiDictionary<object, IStructuralReadWrite> Entries = new(GenericEqualityComparer.Instance, GenericEqualityComparer.Instance);
+        private readonly MultiDictionary<object, IStructuralReadWrite> Entries = new(EqualityComparer<object>.Default, EqualityComparer<Object>.Default);
 
         // The function to use for decoding a type value.
         IStructuralReadWrite IRemoteTableHandle.DecodeValue(BinaryReader reader) => IStructuralReadWrite.Read<Row>(reader);
@@ -302,37 +302,5 @@ namespace SpacetimeDB
             wasRemoved.Clear();
 
         }
-    }
-
-    /// <summary>
-    /// EqualityComparer used to compare primary keys.
-    /// 
-    /// If the primary keys are byte arrays (i.e. if the table has no primary key), uses Internal.ByteArrayComparer.
-    /// Otherwise, falls back to .Equals().
-    /// 
-    /// TODO: we should test that this works for all of our supported primary key types.
-    /// </summary>
-    internal readonly struct GenericEqualityComparer : IEqualityComparer<object>
-    {
-        public static GenericEqualityComparer Instance = new();
-
-        public new bool Equals(object x, object y)
-        {
-            if (x is byte[] x_ && y is byte[] y_)
-            {
-                return Internal.ByteArrayComparer.Instance.Equals(x_, y_);
-            }
-            return x.Equals(y); // MAKE SURE to use .Equals and not ==... that was a bug.
-        }
-
-        public int GetHashCode(object obj)
-        {
-            if (obj is byte[] obj_)
-            {
-                return Internal.ByteArrayComparer.Instance.GetHashCode(obj_);
-            }
-            return obj.GetHashCode();
-        }
-
     }
 }

--- a/tests~/MultiDictionaryTests.cs
+++ b/tests~/MultiDictionaryTests.cs
@@ -345,18 +345,18 @@ public class MultiDictionaryTests
     {
         // GenericEqualityComparer used to have a bug, this is a regression test for that.
         var identity = Identity.From(Convert.FromBase64String("l0qzG1GPRtC1mwr+54q98tv0325gozLc6cNzq4vrzqY="));
-        var hashSet = new HashSet<object>(GenericEqualityComparer.Instance)
+        var hashSet = new HashSet<object>(EqualityComparer<object>.Default)
         {
             identity
         };
         Debug.Assert(hashSet.Contains(identity));
 
-        var dict = new MultiDictionary<object, byte>(GenericEqualityComparer.Instance, EqualityComparer<byte>.Default);
+        var dict = new MultiDictionary<object, byte>(EqualityComparer<object>.Default, EqualityComparer<byte>.Default);
 
         dict.Add(identity, 3);
         dict.Add(identity, 3);
 
-        var delta = new MultiDictionaryDelta<object, byte>(GenericEqualityComparer.Instance, EqualityComparer<byte>.Default);
+        var delta = new MultiDictionaryDelta<object, byte>(EqualityComparer<object>.Default, EqualityComparer<byte>.Default);
         delta.Remove(identity, 3);
         delta.Remove(identity, 3);
         var wasInserted = new List<KeyValuePair<object, byte>>();

--- a/tests~/Tests.cs
+++ b/tests~/Tests.cs
@@ -5,19 +5,10 @@ using SpacetimeDB.Types;
 public class Tests
 {
     [Fact]
-    public static void GenericEqualityComparerCheck()
+    public static void DefaultEqualityComparerCheck()
     {
-        // Validates the behavior of the GenericEqualityComparer's Equals function
-
-        // Byte Arrays
-        byte[] byteArray = new byte[10];
-        byte[] byteArrayByRef = byteArray;
-        byte[] byteArrayByValue = new byte[10];
-        byte[] byteArrayUnequalValue = new byte[01];
-
-        Assert.True(GenericEqualityComparer.Instance.Equals(byteArray, byteArrayByRef));
-        Assert.True(GenericEqualityComparer.Instance.Equals(byteArray, byteArrayByValue));
-        Assert.False(GenericEqualityComparer.Instance.Equals(byteArray, byteArrayUnequalValue));
+        // Sanity check on the behavior of the default EqualityComparer's Equals function w.r.t. spacetime types.
+        var comparer = EqualityComparer<object>.Default;
 
         // Integers
         int integer = 5;
@@ -25,10 +16,10 @@ public class Tests
         int integerUnequalValue = 7;
         string integerAsDifferingType = "5";
 
-        Assert.True(GenericEqualityComparer.Instance.Equals(integer, integerByValue));
-        Assert.False(GenericEqualityComparer.Instance.Equals(integer, integerUnequalValue));
+        Assert.True(comparer.Equals(integer, integerByValue));
+        Assert.False(comparer.Equals(integer, integerUnequalValue));
         // GenericEqualityComparer does not support to converting datatypes and will fail this test
-        Assert.False(GenericEqualityComparer.Instance.Equals(integer, integerAsDifferingType));
+        Assert.False(comparer.Equals(integer, integerAsDifferingType));
 
         // String
         string testString = "This is a test";
@@ -36,9 +27,9 @@ public class Tests
         string testStringByValue = "This is a test";
         string testStringUnequalValue = "This is not the same string";
 
-        Assert.True(GenericEqualityComparer.Instance.Equals(testString, testStringByRef));
-        Assert.True(GenericEqualityComparer.Instance.Equals(testString, testStringByValue));
-        Assert.False(GenericEqualityComparer.Instance.Equals(testString, testStringUnequalValue));
+        Assert.True(comparer.Equals(testString, testStringByRef));
+        Assert.True(comparer.Equals(testString, testStringByValue));
+        Assert.False(comparer.Equals(testString, testStringUnequalValue));
 
         // Note: We are limited to only [SpacetimeDB.Type]
 
@@ -55,15 +46,15 @@ public class Tests
         User testUserUnequalNameValue = new User { Identity = identity, Name = "unequalName", Online = false };
         User testUserUnequalOnlineValue = new User { Identity = identity, Name = "name", Online = true };
 
-        Assert.True(GenericEqualityComparer.Instance.Equals(identity, identityByRef));
-        Assert.True(GenericEqualityComparer.Instance.Equals(identity, identityByValue));
-        Assert.False(GenericEqualityComparer.Instance.Equals(identity, identityUnequalValue));
+        Assert.True(comparer.Equals(identity, identityByRef));
+        Assert.True(comparer.Equals(identity, identityByValue));
+        Assert.False(comparer.Equals(identity, identityUnequalValue));
 
-        Assert.True(GenericEqualityComparer.Instance.Equals(testUser, testUserByRef));
-        Assert.True(GenericEqualityComparer.Instance.Equals(testUser, testUserByValue));
-        Assert.False(GenericEqualityComparer.Instance.Equals(testUser, testUserUnequalIdentityValue));
-        Assert.False(GenericEqualityComparer.Instance.Equals(testUser, testUserUnequalNameValue));
-        Assert.False(GenericEqualityComparer.Instance.Equals(testUser, testUserUnequalOnlineValue));
+        Assert.True(comparer.Equals(testUser, testUserByRef));
+        Assert.True(comparer.Equals(testUser, testUserByValue));
+        Assert.False(comparer.Equals(testUser, testUserUnequalIdentityValue));
+        Assert.False(comparer.Equals(testUser, testUserUnequalNameValue));
+        Assert.False(comparer.Equals(testUser, testUserUnequalOnlineValue));
 
         // TaggedEnum using Status record
         Status statusCommitted = new Status.Committed(default);
@@ -74,11 +65,11 @@ public class Tests
         Status statusFailedUnequalValue = new Status.Failed("unequalFailed");
         Status statusOutOfEnergy = new Status.OutOfEnergy(default);
 
-        Assert.True(GenericEqualityComparer.Instance.Equals(statusCommitted, statusCommittedByRef));
-        Assert.True(GenericEqualityComparer.Instance.Equals(statusCommitted, statusCommittedByValue));
-        Assert.False(GenericEqualityComparer.Instance.Equals(statusCommitted, statusFailed));
-        Assert.True(GenericEqualityComparer.Instance.Equals(statusFailed, statusFailedByValue));
-        Assert.False(GenericEqualityComparer.Instance.Equals(statusFailed, statusFailedUnequalValue));
-        Assert.False(GenericEqualityComparer.Instance.Equals(statusCommitted, statusOutOfEnergy));
+        Assert.True(comparer.Equals(statusCommitted, statusCommittedByRef));
+        Assert.True(comparer.Equals(statusCommitted, statusCommittedByValue));
+        Assert.False(comparer.Equals(statusCommitted, statusFailed));
+        Assert.True(comparer.Equals(statusFailed, statusFailedByValue));
+        Assert.False(comparer.Equals(statusFailed, statusFailedUnequalValue));
+        Assert.False(comparer.Equals(statusCommitted, statusOutOfEnergy));
     }
 }


### PR DESCRIPTION
This purges the DbValue type, instead using row instances themselves as primary key for rows without primary keys. In addition, it instantiates only a single BinaryReader when reading updates for a table, rather than instantiating a BinaryReader and performing an array copy per-row of the table.

Addresses https://github.com/clockworklabs/SpacetimeDBPrivate/issues/1633

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*

## Requires SpacetimeDB PRs

## Testsuite

SpacetimeDB branch name: master

## Testing
*Write instructions for a test that you performed for this PR*

- [ ] CI