### PR TITLE
Convert problem Linq calls to custom enumerators

### DIFF
--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -391,20 +391,20 @@ namespace SpacetimeDB
             {
                 if (_index >= _maxIndex)
                     return false;
-                    
+
                 _index++;
-                
+
                 // Create the array only when requested
                 var startIndex = _index * _size;
                 if (startIndex + _size > _rowsData.Count)
                     return false;
-                    
+
                 _current = new byte[_size];
                 for (var i = 0; i < _size; i++)
                 {
                     _current[i] = _rowsData[startIndex + i];
                 }
-                
+
                 return true;
             }
 
@@ -442,23 +442,23 @@ namespace SpacetimeDB
                 if (_index >= _offsets.Count - 1)
                     return false;
                 _index++;
-                
+
                 // Determine start and end indices
                 var startIndex = (int)_offsets[_index];
-                var endIndex = (_index + 1 < _offsets.Count) 
-                    ? (int)_offsets[_index + 1] 
+                var endIndex = (_index + 1 < _offsets.Count)
+                    ? (int)_offsets[_index + 1]
                     : _rowsData.Count;
-                    
+
                 var length = endIndex - startIndex;
                 if (length <= 0)
                     return false;
-                    
+
                 _current = new byte[length];
                 for (var i = 0; i < length; i++)
                 {
                     _current[i] = _rowsData[startIndex + i];
                 }
-                
+
                 return true;
             }
 

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -357,6 +357,12 @@ namespace SpacetimeDB
         {
             var rowsData = list.RowsData;
 
+            // Previously here we were using LINQ to do what we're now doing with the custom row iterators. This
+            // is because the LINQ statements were fast under the Mono runtime (which Unity uses in the Editor
+            // but also in builds if it's enabled), but *a lot* slower under IL2CPP. This has to do with differences
+            // between how Mono uses JIT VS how IL2CPP uses AOT. Apparently Mono's JIT is smart enough to inline
+            // most of the LINQ ops but IL2CPP's AOT is not.
+            // See: https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/pull/306
             return list.SizeHint switch
             {
                 RowSizeHint.FixedSize(var size) => new FixedSizeRowIterator(rowsData, size),

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -358,10 +358,9 @@ namespace SpacetimeDB
             var rowsData = list.RowsData;
 
             // Previously here we were using LINQ to do what we're now doing with the custom row iterators. This
-            // is because the LINQ statements were fast under the Mono runtime (which Unity uses in the Editor
-            // but also in builds if it's enabled), but *a lot* slower under IL2CPP. This has to do with differences
-            // between how Mono uses JIT VS how IL2CPP uses AOT. Apparently Mono's JIT is smart enough to inline
-            // most of the LINQ ops but IL2CPP's AOT is not.
+            // is due to the fact that the LINQ statements were fast under the Mono runtime, but *a lot* slower
+            // under IL2CPP. This has to do with differences between how Mono uses JIT VS how IL2CPP uses AOT.
+            // Apparently Mono's JIT is smart enough to inline most of the LINQ ops but IL2CPP's AOT is not.
             // See: https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/pull/306
             return list.SizeHint switch
             {


### PR DESCRIPTION
## Description of Changes

Fixes https://github.com/clockworklabs/SpacetimeDBPrivate/issues/1647.

This fixes a performance issue where iterating through the BSATN bytes of a subscribe call was very slow. The problematic function was `BsatnRowListIter` in particular.
```cs
private static IEnumerable<byte[]> BsatnRowListIter(BsatnRowList list)
{
    var rowsData = list.RowsData;

    return list.SizeHint switch
    {
        RowSizeHint.FixedSize(var size) => Enumerable
            .Range(0, rowsData.Count / size)
            .Select(index => rowsData.Skip(index * size).Take(size).ToArray()),

        RowSizeHint.RowOffsets(var offsets) => offsets.Zip(
            offsets.Skip(1).Append((ulong)rowsData.Count),
            (start, end) => rowsData.Take((int)end).Skip((int)start).ToArray()
        ),

        _ => throw new InvalidOperationException("Unknown RowSizeHint variant"),
    };
}
```

And within this function, the problem was specifically the Linq calls `Skip` and `Take`.

Note that `Skip` by default is a linear time operation - reading `rowsData` from the beginning to the passed index. In this case, that means reading the bytes of an entire table from the beginning just to read the next row.

Mono's jit compiler is clever enough to recognize the `Skip().Take()` combination and optimize this completely way so that it only reads the bytes of each row on each call, resulting in a linear scan of the table.

IL2CPP's aot compiler however cannot do this, and so it resorts to the default algorithm which results in a quadratic time scan of the table.

Ultimately the fix was to not rely on the runtime/compiler to optimize declaratively defined Linq code, but rather to define an imperative linear-time algorithm.

## API

Not API breaking.

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*

## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*

- None

## Testsuite
*If you would like to run the your SDK changes in this PR against a specific SpacetimeDB branch, specify that here. This can be a branch name or a link to a PR.*

SpacetimeDB branch name: master

## Testing
*Write instructions for a test that you performed for this PR*

- [x] Tested against BitCraft and the performance regressions are gone.
