### PR TITLE
Pre-process messages in parallel.

### DIFF
--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -432,7 +432,7 @@ namespace SpacetimeDB
         }
 
         /// <summary>
-        /// *Maybe* do something in parallel, depending on how many bytes we need to process.
+        /// An optimized ForEach, depending on how many bytes we need to process.
         /// For small messages, avoid the overhead from parallelizing.
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -401,11 +401,16 @@ namespace SpacetimeDB
 
             /// <summary>
             /// The updates to parse.
+            /// There may be multiple TableUpdates corresponding to a single table.
+            /// (Each TableUpdate then contains multiple CompressableQueryUpdates.
+            /// Unfortunately, these are compressed independently due to serverside limitations.)
             /// </summary>
             public List<TableUpdate> Updates;
 
             /// <summary>
             /// The delta to fill with data. Starts out empty.
+            /// This delta is also stored in a ProcessedDatabaseUpdate, so modifying it
+            /// directly modifies a ProcessedDatabaseUpdate that needs to be filled in with data.
             /// </summary>
             public MultiDictionaryDelta<object, PreHashedRow> Delta;
         }
@@ -441,7 +446,9 @@ namespace SpacetimeDB
 
             IEnumerable<UpdatesToPreProcess> GetUpdatesToPreProcess(DatabaseUpdate updates, ProcessedDatabaseUpdate dbOps)
             {
-                Dictionary<IRemoteTableHandle, UpdatesToPreProcess> tableToUpdates = new(32);
+                // There may be multiple TableUpdates corresponding to a single table in a DatabaseUpdate.
+                // Preemptively group them.
+                Dictionary<IRemoteTableHandle, UpdatesToPreProcess> tableToUpdates = new(updates.Tables.Count);
                 foreach (var update in updates.Tables)
                 {
                     var tableName = update.TableName;

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -433,13 +433,14 @@ namespace SpacetimeDB
 
         /// <summary>
         /// *Maybe* do something in parallel, depending on how many bytes we need to process.
+        /// For small messages, avoid the overhead from parallelizing.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="values">The enumerator to consume.</param>
         /// <param name="action">The action to perform for each element of the enumerator.</param>
         /// <param name="bytes">The number of bytes in the compressed message.</param>
         /// <param name="enoughBytesToParallelize">The threshold for whether to parse updates on multiple threads.</param>
-        static void MaybeParallelForEach<T>(
+        static void FastParallelForEach<T>(
             IEnumerable<T> values,
             Action<T> action,
             int bytes,

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -528,7 +528,7 @@ namespace SpacetimeDB
             {
                 var dbOps = ProcessedDatabaseUpdate.New();
 
-                MaybeParallelForEach(GetUpdatesToPreProcess(initSub.DatabaseUpdate, dbOps), (todo) =>
+                FastParallelForEach(GetUpdatesToPreProcess(initSub.DatabaseUpdate, dbOps), (todo) =>
                 {
                     PreProcessInsertOnlyTable(todo);
                 }, bytes: messageBytes);
@@ -542,7 +542,7 @@ namespace SpacetimeDB
             ProcessedDatabaseUpdate PreProcessSubscribeMultiApplied(SubscribeMultiApplied subscribeMultiApplied, int messageBytes)
             {
                 var dbOps = ProcessedDatabaseUpdate.New();
-                MaybeParallelForEach(GetUpdatesToPreProcess(subscribeMultiApplied.Update, dbOps), (todo) =>
+                FastParallelForEach(GetUpdatesToPreProcess(subscribeMultiApplied.Update, dbOps), (todo) =>
                 {
                     PreProcessInsertOnlyTable(todo);
                 }, bytes: messageBytes);
@@ -624,7 +624,7 @@ namespace SpacetimeDB
             {
                 var dbOps = ProcessedDatabaseUpdate.New();
 
-                MaybeParallelForEach(GetUpdatesToPreProcess(unsubMultiApplied.Update, dbOps), (todo) =>
+                FastParallelForEach(GetUpdatesToPreProcess(unsubMultiApplied.Update, dbOps), (todo) =>
                 {
                     PreProcessDeleteOnlyTable(todo);
                 }, bytes: messageBytes);
@@ -636,7 +636,7 @@ namespace SpacetimeDB
             {
                 var dbOps = ProcessedDatabaseUpdate.New();
 
-                MaybeParallelForEach(GetUpdatesToPreProcess(updates, dbOps), (todo) =>
+                FastParallelForEach(GetUpdatesToPreProcess(updates, dbOps), (todo) =>
                 {
                     PreProcessTable(todo);
                 }, bytes: messageBytes);

--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -435,15 +435,15 @@ namespace SpacetimeDB
         /// *Maybe* do something in parallel, depending on how many bytes we need to process.
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="values"></param>
-        /// <param name="action"></param>
-        /// <param name="bytes"></param>
-        /// <param name="enoughBytesToParallelize"></param>
+        /// <param name="values">The enumerator to consume.</param>
+        /// <param name="action">The action to perform for each element of the enumerator.</param>
+        /// <param name="bytes">The number of bytes in the compressed message.</param>
+        /// <param name="enoughBytesToParallelize">The threshold for whether to parse updates on multiple threads.</param>
         static void MaybeParallelForEach<T>(
             IEnumerable<T> values,
             Action<T> action,
             int bytes,
-            int enoughBytesToParallelize = 64_000
+            int enoughBytesToParallelize = 32_000
         )
         {
             if (bytes >= enoughBytesToParallelize)


### PR DESCRIPTION
## Description of Changes
Parallelizes the pre-processing of messages. This should significantly reduce the latency of initial subscription parsing.

## API

 - [ ] This is an API breaking change to the SDK


## Requires SpacetimeDB PRs
*List any PRs here that are required for this SDK change to work*

## Testsuite

SpacetimeDB branch name: master

## Testing

- [ ] Describe a test for this PR that you have completed
