### PR TITLE
Bump versions to 1.1.5

### DIFF
--- a/SpacetimeDB.ClientSDK.csproj
+++ b/SpacetimeDB.ClientSDK.csproj
@@ -16,8 +16,8 @@
     <PackageIcon>logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk</RepositoryUrl>
-    <AssemblyVersion>1.1.1</AssemblyVersion>
-    <Version>1.1.1</Version>
+    <AssemblyVersion>1.1.5</AssemblyVersion>
+    <Version>1.1.5</Version>
     <DefaultItemExcludes>$(DefaultItemExcludes);*~/**</DefaultItemExcludes>
     <!-- We want to save DLLs for Unity which doesn't support NuGet. -->
     <RestorePackagesPath>packages</RestorePackagesPath>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.clockworklabs.spacetimedbsdk",
   "displayName": "SpacetimeDB SDK",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "The SpacetimeDB Client SDK is a software development kit (SDK) designed to interact with and manipulate SpacetimeDB modules..",
   "keywords": [],
   "author": {


### PR DESCRIPTION
## Description of Changes
Just bumping version numbers in preparation for a release.

The Unity SDK and C# SDK had different version numbers. That seems confusing, so I bumped them both to 1.1.5.

## API

No breaking changes

## Requires SpacetimeDB PRs
None, afaik

## Testsuite
SpacetimeDB branch name: master

## Testing
None