### PR TITLE
More granular request process tracking

### DIFF
--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -127,7 +127,6 @@ namespace SpacetimeDB
     {
         public static DbConnectionBuilder<DbConnection> Builder() => new();
 
-
         internal event Action<Identity, string>? onConnect;
 
         /// <summary>
@@ -168,7 +167,7 @@ namespace SpacetimeDB
         private readonly Dictionary<Guid, TaskCompletionSource<OneOffQueryResponse>> waitingOneOffQueries = new();
 
         private bool isClosing;
-        private readonly Thread networkMessageProcessThread;
+        private readonly Thread networkMessageParseThread;
         public readonly Stats stats = new();
 
         protected DbConnectionBase()
@@ -193,24 +192,36 @@ namespace SpacetimeDB
             
 #if UNITY_WEBGL && !UNITY_EDITOR
             if (SpacetimeDBNetworkManager._instance != null)
-                SpacetimeDBNetworkManager._instance.StartCoroutine(PreProcessMessages());
+                SpacetimeDBNetworkManager._instance.StartCoroutine(ParseMessages());
 #endif
 #endif
 
 #if !(UNITY_WEBGL && !UNITY_EDITOR)
-            // For targets other than webgl we start a thread to pre-process messages
-            networkMessageProcessThread = new Thread(PreProcessMessages);
-            networkMessageProcessThread.Start();
+            // For targets other than webgl we start a thread to parse messages
+            networkMessageParseThread = new Thread(ParseMessages);
+            networkMessageParseThread.Start();
 #endif
         }
 
-        struct UnprocessedMessage
+        internal struct UnparsedMessage
         {
+            /// <summary>
+            /// The bytes of the message.
+            /// </summary>
             public byte[] bytes;
+
+            /// <summary>
+            /// The timestamp the message came off the wire.
+            /// </summary>
             public DateTime timestamp;
+
+            /// <summary>
+            /// The ID assigned by the message parsing queue tracker.
+            /// </summary>
+            public uint parseQueueTrackerId;
         }
 
-        struct ProcessedDatabaseUpdate
+        internal struct ParsedDatabaseUpdate
         {
             // Map: table handles -> (primary key -> IStructuralReadWrite).
             // If a particular table has no primary key, the "primary key" is just the row itself.
@@ -218,9 +229,9 @@ namespace SpacetimeDB
             public Dictionary<IRemoteTableHandle, MultiDictionaryDelta<object, IStructuralReadWrite>> Updates;
 
             // Can't override the default constructor. Make sure you use this one!
-            public static ProcessedDatabaseUpdate New()
+            public static ParsedDatabaseUpdate New()
             {
-                ProcessedDatabaseUpdate result;
+                ParsedDatabaseUpdate result;
                 result.Updates = new();
                 return result;
             }
@@ -237,26 +248,26 @@ namespace SpacetimeDB
             }
         }
 
-        struct ProcessedMessage
+        internal struct ParsedMessage
         {
             public ServerMessage message;
-            public ProcessedDatabaseUpdate dbOps;
+            public ParsedDatabaseUpdate dbOps;
             public DateTime receiveTimestamp;
-            public uint applyTracker;
+            public uint applyQueueTrackerId;
             public ReducerEvent<Reducer>? reducerEvent;
         }
 
-        private readonly BlockingCollection<UnprocessedMessage> _messageQueue =
-            new(new ConcurrentQueue<UnprocessedMessage>());
+        private readonly BlockingCollection<UnparsedMessage> _parseQueue =
+            new(new ConcurrentQueue<UnparsedMessage>());
 
-        private readonly BlockingCollection<ProcessedMessage> _preProcessedNetworkMessages =
-            new(new ConcurrentQueue<ProcessedMessage>());
+        private readonly BlockingCollection<ParsedMessage> _applyQueue =
+            new(new ConcurrentQueue<ParsedMessage>());
 
         internal static bool IsTesting;
-        internal bool HasPreProcessedMessage => _preProcessedNetworkMessages.Count > 0;
+        internal bool HasMessageToApply => _applyQueue.Count > 0;
 
-        private readonly CancellationTokenSource _preProcessCancellationTokenSource = new();
-        private CancellationToken _preProcessCancellationToken => _preProcessCancellationTokenSource.Token;
+        private readonly CancellationTokenSource _parseCancellationTokenSource = new();
+        private CancellationToken _parseCancellationToken => _parseCancellationTokenSource.Token;
 
         /// <summary>
         /// Decode a row for a table, producing a primary key.
@@ -267,7 +278,7 @@ namespace SpacetimeDB
         /// <param name="reader"></param>
         /// <param name="primaryKey"></param>
         /// <returns></returns>
-        static IStructuralReadWrite Decode(IRemoteTableHandle table, BinaryReader reader, out object primaryKey)
+        internal static IStructuralReadWrite Decode(IRemoteTableHandle table, BinaryReader reader, out object primaryKey)
         {
             var obj = table.DecodeValue(reader);
 
@@ -283,7 +294,7 @@ namespace SpacetimeDB
         private static readonly Status Committed = new Status.Committed(default);
         private static readonly Status OutOfEnergy = new Status.OutOfEnergy(default);
 
-        enum CompressionAlgos : byte
+        internal enum CompressionAlgos : byte
         {
             None = 0,
             Brotli = 1,
@@ -388,10 +399,21 @@ namespace SpacetimeDB
                 }
             );
 
+        /// <summary>
+        /// Get a description of a message suitable for storing in the tracker metadata.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        internal string TrackerMetadataForMessage(ServerMessage message) => message switch
+        {
+            ServerMessage.TransactionUpdate(var transactionUpdate) => $"type={nameof(ServerMessage.TransactionUpdate)},reducer={transactionUpdate.ReducerCall.ReducerName}",
+            _ => $"type={message.GetType().Name}"
+        };
+
 #if UNITY_WEBGL && !UNITY_EDITOR
-        IEnumerator PreProcessMessages()
+        internal IEnumerator ParseMessages()
 #else
-        void PreProcessMessages()
+        internal void ParseMessages()
 #endif
         {
             while (!isClosing)
@@ -403,9 +425,9 @@ namespace SpacetimeDB
 #endif
                 try
                 {
-                    var message = _messageQueue.Take(_preProcessCancellationToken);
-                    var preprocessedMessage = PreProcessMessage(message);
-                    _preProcessedNetworkMessages.Add(preprocessedMessage, _preProcessCancellationToken);
+                    var message = _parseQueue.Take(_parseCancellationToken);
+                    var parsedMessage = ParseMessage(message);
+                    _applyQueue.Add(parsedMessage, _parseCancellationToken);
                 }
                 catch (OperationCanceledException)
                 {
@@ -432,16 +454,16 @@ namespace SpacetimeDB
                 }
             }
 
-            ProcessedDatabaseUpdate PreProcessLegacySubscription(InitialSubscription initSub)
+            ParsedDatabaseUpdate ParseLegacySubscription(InitialSubscription initSub)
             {
-                var dbOps = ProcessedDatabaseUpdate.New();
+                var dbOps = ParsedDatabaseUpdate.New();
                 // This is all of the inserts
                 int cap = initSub.DatabaseUpdate.Tables.Sum(a => (int)a.NumRows);
 
                 // First apply all of the state
                 foreach (var (table, update) in GetTables(initSub.DatabaseUpdate))
                 {
-                    PreProcessInsertOnlyTable(table, update, dbOps);
+                    ParseInsertOnlyTable(table, update, dbOps);
                 }
                 return dbOps;
             }
@@ -450,17 +472,17 @@ namespace SpacetimeDB
             /// TODO: the dictionary is here for backwards compatibility and can be removed
             /// once we get rid of legacy subscriptions.
             /// </summary>
-            ProcessedDatabaseUpdate PreProcessSubscribeMultiApplied(SubscribeMultiApplied subscribeMultiApplied)
+            ParsedDatabaseUpdate ParseSubscribeMultiApplied(SubscribeMultiApplied subscribeMultiApplied)
             {
-                var dbOps = ProcessedDatabaseUpdate.New();
+                var dbOps = ParsedDatabaseUpdate.New();
                 foreach (var (table, update) in GetTables(subscribeMultiApplied.Update))
                 {
-                    PreProcessInsertOnlyTable(table, update, dbOps);
+                    ParseInsertOnlyTable(table, update, dbOps);
                 }
                 return dbOps;
             }
 
-            void PreProcessInsertOnlyTable(IRemoteTableHandle table, TableUpdate update, ProcessedDatabaseUpdate dbOps)
+            void ParseInsertOnlyTable(IRemoteTableHandle table, TableUpdate update, ParsedDatabaseUpdate dbOps)
             {
                 var delta = dbOps.DeltaForTable(table);
 
@@ -480,7 +502,7 @@ namespace SpacetimeDB
                 }
             }
 
-            void PreProcessDeleteOnlyTable(IRemoteTableHandle table, TableUpdate update, ProcessedDatabaseUpdate dbOps)
+            void ParseDeleteOnlyTable(IRemoteTableHandle table, TableUpdate update, ParsedDatabaseUpdate dbOps)
             {
                 var delta = dbOps.DeltaForTable(table);
                 foreach (var cqu in update.Updates)
@@ -500,7 +522,7 @@ namespace SpacetimeDB
                 }
             }
 
-            void PreProcessTable(IRemoteTableHandle table, TableUpdate update, ProcessedDatabaseUpdate dbOps)
+            void ParseTable(IRemoteTableHandle table, TableUpdate update, ParsedDatabaseUpdate dbOps)
             {
                 var delta = dbOps.DeltaForTable(table);
                 foreach (var cqu in update.Updates)
@@ -527,30 +549,30 @@ namespace SpacetimeDB
 
             }
 
-            ProcessedDatabaseUpdate PreProcessUnsubscribeMultiApplied(UnsubscribeMultiApplied unsubMultiApplied)
+            ParsedDatabaseUpdate ParseUnsubscribeMultiApplied(UnsubscribeMultiApplied unsubMultiApplied)
             {
-                var dbOps = ProcessedDatabaseUpdate.New();
+                var dbOps = ParsedDatabaseUpdate.New();
 
                 foreach (var (table, update) in GetTables(unsubMultiApplied.Update))
                 {
-                    PreProcessDeleteOnlyTable(table, update, dbOps);
+                    ParseDeleteOnlyTable(table, update, dbOps);
                 }
 
                 return dbOps;
             }
 
-            ProcessedDatabaseUpdate PreProcessDatabaseUpdate(DatabaseUpdate updates)
+            ParsedDatabaseUpdate ParseDatabaseUpdate(DatabaseUpdate updates)
             {
-                var dbOps = ProcessedDatabaseUpdate.New();
+                var dbOps = ParsedDatabaseUpdate.New();
 
                 foreach (var (table, update) in GetTables(updates))
                 {
-                    PreProcessTable(table, update, dbOps);
+                    ParseTable(table, update, dbOps);
                 }
                 return dbOps;
             }
 
-            void PreProcessOneOffQuery(OneOffQueryResponse resp)
+            void ParseOneOffQuery(OneOffQueryResponse resp)
             {
                 /// This case does NOT produce a list of DBOps, because it should not modify the client cache state!
                 var messageId = new Guid(resp.MessageId.ToArray());
@@ -564,44 +586,47 @@ namespace SpacetimeDB
                 resultSource.SetResult(resp);
             }
 
-            ProcessedMessage PreProcessMessage(UnprocessedMessage unprocessed)
+            ParsedMessage ParseMessage(UnparsedMessage unparsed)
             {
-                var dbOps = ProcessedDatabaseUpdate.New();
+                var dbOps = ParsedDatabaseUpdate.New();
+                var message = DecompressDecodeMessage(unparsed.bytes);
+                var trackerMetadata = TrackerMetadataForMessage(message);
 
-                var message = DecompressDecodeMessage(unprocessed.bytes);
+                stats.ParseMessageQueueTracker.FinishTrackingRequest(unparsed.parseQueueTrackerId, trackerMetadata);
+                var parseStart = DateTime.UtcNow;
 
                 ReducerEvent<Reducer>? reducerEvent = default;
 
                 switch (message)
                 {
                     case ServerMessage.InitialSubscription(var initSub):
-                        stats.SubscriptionRequestTracker.FinishTrackingRequest(initSub.RequestId);
-                        dbOps = PreProcessLegacySubscription(initSub);
-                        stats.ParseMessageTracker.InsertRequest(unprocessed.timestamp, $"type={nameof(ServerMessage.InitialSubscription)}");
+                        stats.SubscriptionRequestTracker.FinishTrackingRequest(initSub.RequestId, unparsed.timestamp);
+                        dbOps = ParseLegacySubscription(initSub);
                         break;
                     case ServerMessage.SubscribeApplied(var subscribeApplied):
                         break;
                     case ServerMessage.SubscribeMultiApplied(var subscribeMultiApplied):
-                        stats.SubscriptionRequestTracker.FinishTrackingRequest(subscribeMultiApplied.RequestId);
-                        dbOps = PreProcessSubscribeMultiApplied(subscribeMultiApplied);
-                        stats.ParseMessageTracker.InsertRequest(unprocessed.timestamp, $"type={nameof(ServerMessage.SubscribeMultiApplied)}");
+                        stats.SubscriptionRequestTracker.FinishTrackingRequest(subscribeMultiApplied.RequestId, unparsed.timestamp);
+                        dbOps = ParseSubscribeMultiApplied(subscribeMultiApplied);
                         break;
                     case ServerMessage.SubscriptionError(var subscriptionError):
                         // do nothing; main thread will warn.
-                        stats.ParseMessageTracker.InsertRequest(unprocessed.timestamp, $"type={nameof(ServerMessage.SubscriptionError)}");
+                        if (subscriptionError.RequestId.HasValue)
+                        {
+                            stats.SubscriptionRequestTracker.FinishTrackingRequest(subscriptionError.RequestId.Value, unparsed.timestamp);
+                        }
                         break;
                     case ServerMessage.UnsubscribeApplied(var unsubscribeApplied):
                         // do nothing; main thread will warn.
                         break;
                     case ServerMessage.UnsubscribeMultiApplied(var unsubscribeMultiApplied):
-                        dbOps = PreProcessUnsubscribeMultiApplied(unsubscribeMultiApplied);
-                        stats.ParseMessageTracker.InsertRequest(unprocessed.timestamp, $"type={nameof(ServerMessage.UnsubscribeMultiApplied)}");
+                        stats.SubscriptionRequestTracker.FinishTrackingRequest(unsubscribeMultiApplied.RequestId, unparsed.timestamp);
+                        dbOps = ParseUnsubscribeMultiApplied(unsubscribeMultiApplied);
                         break;
                     case ServerMessage.TransactionUpdate(var transactionUpdate):
                         // Convert the generic event arguments in to a domain specific event object
-                        var reducer = transactionUpdate.ReducerCall.ReducerName;
                         var hostDuration = (TimeSpan)transactionUpdate.TotalHostExecutionDuration;
-                        stats.AllReducersTracker.InsertRequest(hostDuration, $"reducer={reducer}");
+                        stats.AllReducersTracker.InsertRequest(hostDuration, $"reducer={transactionUpdate.ReducerCall.ReducerName}");
 
                         try
                         {
@@ -623,7 +648,7 @@ namespace SpacetimeDB
                         {
                             // Failing to parse the ReducerEvent is fine, it just means we should
                             // call downstream stuff with an UnknownTransaction.
-                            // See OnProcessMessageComplete.
+                            // See ApplyMessage
                         }
 
                         var callerIdentity = transactionUpdate.CallerIdentity;
@@ -631,7 +656,10 @@ namespace SpacetimeDB
                         {
                             // This was a request that we initiated
                             var requestId = transactionUpdate.ReducerCall.RequestId;
-                            if (!stats.ReducerRequestTracker.FinishTrackingRequest(requestId))
+                            // Make sure we mark the request as having finished when it came off the wire.
+                            // That's why we use unparsed.timestamp, rather than DateTime.UtcNow.
+                            // See ReducerRequestTracker's comment.
+                            if (!stats.ReducerRequestTracker.FinishTrackingRequest(requestId, unparsed.timestamp))
                             {
                                 Log.Warn($"Failed to finish tracking reducer request: {requestId}");
                             }
@@ -639,29 +667,27 @@ namespace SpacetimeDB
 
                         if (transactionUpdate.Status is UpdateStatus.Committed(var committed))
                         {
-                            dbOps = PreProcessDatabaseUpdate(committed);
+                            dbOps = ParseDatabaseUpdate(committed);
                         }
-
-                        stats.ParseMessageTracker.InsertRequest(unprocessed.timestamp, $"type={nameof(ServerMessage.TransactionUpdate)},reducer={reducer}");
 
                         break;
                     case ServerMessage.TransactionUpdateLight(var update):
-                        dbOps = PreProcessDatabaseUpdate(update.Update);
-                        stats.ParseMessageTracker.InsertRequest(unprocessed.timestamp, $"type={nameof(ServerMessage.TransactionUpdateLight)}");
+                        dbOps = ParseDatabaseUpdate(update.Update);
                         break;
                     case ServerMessage.IdentityToken(var identityToken):
                         break;
                     case ServerMessage.OneOffQueryResponse(var resp):
-                        PreProcessOneOffQuery(resp);
+                        ParseOneOffQuery(resp);
                         break;
 
                     default:
                         throw new InvalidOperationException();
                 }
 
-                var applyTracker = stats.ApplyMessageTracker.StartTrackingRequest($"type={message.GetType().Name}");
+                stats.ParseMessageTracker.InsertRequest(parseStart, trackerMetadata);
+                var applyTracker = stats.ApplyMessageQueueTracker.StartTrackingRequest(trackerMetadata);
 
-                return new ProcessedMessage { message = message, dbOps = dbOps, receiveTimestamp = unprocessed.timestamp, applyTracker = applyTracker, reducerEvent = reducerEvent };
+                return new ParsedMessage { message = message, dbOps = dbOps, receiveTimestamp = unparsed.timestamp, applyQueueTrackerId = applyTracker, reducerEvent = reducerEvent };
             }
         }
 
@@ -676,7 +702,7 @@ namespace SpacetimeDB
                 webSocket.Close();
             }
 
-            _preProcessCancellationTokenSource.Cancel();
+            _parseCancellationTokenSource.Cancel();
         }
 
         /// <summary>
@@ -731,7 +757,7 @@ namespace SpacetimeDB
         }
 
 
-        private void OnMessageProcessCompleteUpdate(IEventContext eventContext, ProcessedDatabaseUpdate dbOps)
+        private void ApplyUpdate(IEventContext eventContext, ParsedDatabaseUpdate dbOps)
         {
             // First trigger OnBeforeDelete
             foreach (var (table, update) in dbOps.Updates)
@@ -752,11 +778,14 @@ namespace SpacetimeDB
 
         protected abstract bool Dispatch(IReducerEventContext context, Reducer reducer);
 
-        private void OnMessageProcessComplete(ProcessedMessage processed)
+        private void ApplyMessage(ParsedMessage parsed)
         {
-            var message = processed.message;
-            var dbOps = processed.dbOps;
-            var timestamp = processed.receiveTimestamp;
+            var message = parsed.message;
+            var dbOps = parsed.dbOps;
+            var timestamp = parsed.receiveTimestamp;
+
+            stats.ApplyMessageQueueTracker.FinishTrackingRequest(parsed.applyQueueTrackerId);
+            var applyStart = DateTime.UtcNow;
 
             switch (message)
             {
@@ -764,7 +793,7 @@ namespace SpacetimeDB
                     {
                         var eventContext = MakeSubscriptionEventContext();
                         var legacyEventContext = ToEventContext(new Event<Reducer>.SubscribeApplied());
-                        OnMessageProcessCompleteUpdate(legacyEventContext, dbOps);
+                        ApplyUpdate(legacyEventContext, dbOps);
 
                         if (legacySubscriptions.TryGetValue(initialSubscription.RequestId, out var subscription))
                         {
@@ -788,7 +817,7 @@ namespace SpacetimeDB
                     {
                         var eventContext = MakeSubscriptionEventContext();
                         var legacyEventContext = ToEventContext(new Event<Reducer>.SubscribeApplied());
-                        OnMessageProcessCompleteUpdate(legacyEventContext, dbOps);
+                        ApplyUpdate(legacyEventContext, dbOps);
                         if (subscriptions.TryGetValue(subscribeMultiApplied.QueryId.Id, out var subscription))
                         {
                             try
@@ -807,15 +836,12 @@ namespace SpacetimeDB
                 case ServerMessage.SubscriptionError(var subscriptionError):
                     {
                         Log.Warn($"Subscription Error: ${subscriptionError.Error}");
-                        if (subscriptionError.RequestId.HasValue)
-                        {
-                            stats.SubscriptionRequestTracker.FinishTrackingRequest(subscriptionError.RequestId.Value);
-                        }
+
                         // TODO: should I use a more specific exception type here?
                         var exception = new Exception(subscriptionError.Error);
                         var eventContext = ToErrorContext(exception);
                         var legacyEventContext = ToEventContext(new Event<Reducer>.SubscribeError(exception));
-                        OnMessageProcessCompleteUpdate(legacyEventContext, dbOps);
+                        ApplyUpdate(legacyEventContext, dbOps);
                         if (subscriptionError.QueryId.HasValue)
                         {
                             if (subscriptions.TryGetValue(subscriptionError.QueryId.Value, out var subscription))
@@ -845,10 +871,9 @@ namespace SpacetimeDB
 
                 case ServerMessage.UnsubscribeMultiApplied(var unsubscribeMultiApplied):
                     {
-                        stats.SubscriptionRequestTracker.FinishTrackingRequest(unsubscribeMultiApplied.RequestId);
                         var eventContext = MakeSubscriptionEventContext();
                         var legacyEventContext = ToEventContext(new Event<Reducer>.UnsubscribeApplied());
-                        OnMessageProcessCompleteUpdate(legacyEventContext, dbOps);
+                        ApplyUpdate(legacyEventContext, dbOps);
                         if (subscriptions.TryGetValue(unsubscribeMultiApplied.QueryId.Id, out var subscription))
                         {
                             try
@@ -866,17 +891,17 @@ namespace SpacetimeDB
                 case ServerMessage.TransactionUpdateLight(var update):
                     {
                         var eventContext = ToEventContext(new Event<Reducer>.UnknownTransaction());
-                        OnMessageProcessCompleteUpdate(eventContext, dbOps);
+                        ApplyUpdate(eventContext, dbOps);
 
                         break;
                     }
 
                 case ServerMessage.TransactionUpdate(var transactionUpdate):
                     {
-                        if (processed.reducerEvent is { } reducerEvent)
+                        if (parsed.reducerEvent is { } reducerEvent)
                         {
                             var legacyEventContext = ToEventContext(new Event<Reducer>.Reducer(reducerEvent));
-                            OnMessageProcessCompleteUpdate(legacyEventContext, dbOps);
+                            ApplyUpdate(legacyEventContext, dbOps);
                             var eventContext = ToReducerEventContext(reducerEvent);
                             Dispatch(eventContext, reducerEvent.Reducer);
                             // don't invoke OnUnhandledReducerError, that's [Obsolete].
@@ -884,7 +909,7 @@ namespace SpacetimeDB
                         else
                         {
                             var legacyEventContext = ToEventContext(new Event<Reducer>.UnknownTransaction());
-                            OnMessageProcessCompleteUpdate(legacyEventContext, dbOps);
+                            ApplyUpdate(legacyEventContext, dbOps);
                         }
                         break;
                     }
@@ -908,12 +933,14 @@ namespace SpacetimeDB
                     throw new InvalidOperationException();
             }
 
-            stats.ApplyMessageTracker.FinishTrackingRequest(processed.applyTracker);
+            stats.ApplyMessageTracker.InsertRequest(applyStart, TrackerMetadataForMessage(message));
         }
 
         // Note: this method is called from unit tests.
-        internal void OnMessageReceived(byte[] bytes, DateTime timestamp) =>
-            _messageQueue.Add(new UnprocessedMessage { bytes = bytes, timestamp = timestamp });
+        internal void OnMessageReceived(byte[] bytes, DateTime timestamp)
+        {
+            _parseQueue.Add(new UnparsedMessage { bytes = bytes, timestamp = timestamp, parseQueueTrackerId = stats.ParseMessageQueueTracker.StartTrackingRequest() });
+        }
 
         // TODO: this should become [Obsolete] but for now is used by autogenerated code.
         void IDbConnection.InternalCallReducer<T>(T args, CallReducerFlags flags)
@@ -1044,9 +1071,9 @@ namespace SpacetimeDB
         public void FrameTick()
         {
             webSocket.Update();
-            while (_preProcessedNetworkMessages.TryTake(out var preProcessedMessage))
+            while (_applyQueue.TryTake(out var parsedMessage))
             {
-                OnMessageProcessComplete(preProcessedMessage);
+                ApplyMessage(parsedMessage);
             }
         }
 

--- a/src/Stats.cs
+++ b/src/Stats.cs
@@ -237,14 +237,16 @@ namespace SpacetimeDB
     {
         /// <summary>
         /// Tracks times from reducers requests being sent to their responses being received.
-        /// This is clientside time, not host-time: for that you want AllReducersTracker.
-        /// Includes the time needed to parse the outer layer of the response message, but not the inner layer
-        /// if it includes a DatabaseUpdate.
+        /// Includes: network send + host + receive + wait in pre-process queue + outer parse.
+        /// 
+        /// (That is, includes the time needed to parse the outer layer of the response message, but not the inner layer
+        /// if it includes a DatabaseUpdate.)
         /// </summary>
         public readonly NetworkRequestTracker ReducerRequestTracker = new();
 
         /// <summary>
         /// Tracks times from one-off requests being sent to their responses being received.
+        /// Includes: network send + host + receive + parse + queue times.
         /// </summary>
         public readonly NetworkRequestTracker OneOffRequestTracker = new();
 
@@ -256,19 +258,21 @@ namespace SpacetimeDB
         public readonly NetworkRequestTracker SubscriptionRequestTracker = new();
 
         /// <summary>
-        /// Tracks HOST-SIDE execution times for reducers.
+        /// Tracks host-side execution times for reducers.
+        /// Includes: host.
         /// </summary>
         public readonly NetworkRequestTracker AllReducersTracker = new();
 
         /// <summary>
         /// Tracks times from messages being received on the wire to their being fully parsed,
         /// but not applied.
-        /// Includes time waiting in the pre-parsing queue.
+        /// Includes: time waiting in preprocessing queue + parse time.
         /// </summary>
         public readonly NetworkRequestTracker ParseMessageTracker = new();
 
         /// <summary>
         /// Tracks times from messages being parsed on a background thread to their being applied on the main thread.
+        /// Includes: time waiting in pre-application queue + apply time.
         /// </summary>
         public readonly NetworkRequestTracker ApplyMessageTracker = new();
     }

--- a/src/Stats.cs
+++ b/src/Stats.cs
@@ -281,18 +281,16 @@ namespace SpacetimeDB
         public readonly NetworkRequestTracker AllReducersTracker = new();
 
         /// <summary>
-        /// Tracks times from messages being received on the wire to their being fully parsed,
-        /// but not applied.
-        /// Includes: time waiting in pre-parsing queue.
+        /// Tracks time between messages being received, and the start of their being parsed.
+        /// Includes: time waiting in parsing queue.
         /// 
         /// GetRequestsAwaitingResponse() is meaningful here.
         /// </summary>
         public readonly NetworkRequestTracker ParseMessageQueueTracker = new();
 
         /// <summary>
-        /// Tracks times from messages being received on the wire to their being fully parsed,
-        /// but not applied.
-        /// Includes: parse time (on background thread).
+        /// Tracks times messages take to be parsed (on a background thread).
+        /// Includes: parse time.
         /// </summary>
         public readonly NetworkRequestTracker ParseMessageTracker = new();
 

--- a/src/Stats.cs
+++ b/src/Stats.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace SpacetimeDB
 {

--- a/src/Stats.cs
+++ b/src/Stats.cs
@@ -236,11 +236,41 @@ namespace SpacetimeDB
 
     public class Stats
     {
+        /// <summary>
+        /// Tracks times from reducers requests being sent to their responses being received.
+        /// This is clientside time, not host-time: for that you want AllReducersTracker.
+        /// Includes the time needed to parse the outer layer of the response message, but not the inner layer
+        /// if it includes a DatabaseUpdate.
+        /// </summary>
         public readonly NetworkRequestTracker ReducerRequestTracker = new();
+
+        /// <summary>
+        /// Tracks times from one-off requests being sent to their responses being received.
+        /// </summary>
         public readonly NetworkRequestTracker OneOffRequestTracker = new();
+
+        /// <summary>
+        /// Tracks times from subscriptions being sent to their responses being received.
+        /// Includes the time needed to parse the outer layer of the response message, but not the inner layer
+        /// if it includes a DatabaseUpdate.
+        /// </summary>
         public readonly NetworkRequestTracker SubscriptionRequestTracker = new();
+
+        /// <summary>
+        /// Tracks HOST-SIDE execution times for reducers.
+        /// </summary>
         public readonly NetworkRequestTracker AllReducersTracker = new();
+
+        /// <summary>
+        /// Tracks times from messages being received on the wire to their being fully parsed,
+        /// but not applied.
+        /// Includes time waiting in the pre-parsing queue.
+        /// </summary>
         public readonly NetworkRequestTracker ParseMessageTracker = new();
+
+        /// <summary>
+        /// Tracks times from messages being parsed on a background thread to their being applied on the main thread.
+        /// </summary>
         public readonly NetworkRequestTracker ApplyMessageTracker = new();
     }
 }

--- a/tests~/SnapshotTests.VerifySampleDump_dumpName=LegacySubscribeAll.verified.txt
+++ b/tests~/SnapshotTests.VerifySampleDump_dumpName=LegacySubscribeAll.verified.txt
@@ -516,15 +516,21 @@
     ReducerRequestTracker: {
       requestsAwaitingResponse: 9
     },
-    OneOffRequestTracker: {},
     SubscriptionRequestTracker: {
       sampleCount: 1
     },
+    OneOffRequestTracker: {},
     AllReducersTracker: {
       sampleCount: 9
     },
+    ParseMessageQueueTracker: {
+      sampleCount: 11
+    },
     ParseMessageTracker: {
-      sampleCount: 10
+      sampleCount: 11
+    },
+    ApplyMessageQueueTracker: {
+      sampleCount: 11
     },
     ApplyMessageTracker: {
       sampleCount: 11

--- a/tests~/SnapshotTests.VerifySampleDump_dumpName=LegacySubscribeAll.verified.txt
+++ b/tests~/SnapshotTests.VerifySampleDump_dumpName=LegacySubscribeAll.verified.txt
@@ -525,6 +525,9 @@
     },
     ParseMessageTracker: {
       sampleCount: 10
+    },
+    ApplyMessageTracker: {
+      sampleCount: 11
     }
   }
 }

--- a/tests~/SnapshotTests.VerifySampleDump_dumpName=SubscribeApplied.verified.txt
+++ b/tests~/SnapshotTests.VerifySampleDump_dumpName=SubscribeApplied.verified.txt
@@ -668,6 +668,9 @@
     },
     ParseMessageTracker: {
       sampleCount: 14
+    },
+    ApplyMessageTracker: {
+      sampleCount: 15
     }
   }
 }

--- a/tests~/SnapshotTests.VerifySampleDump_dumpName=SubscribeApplied.verified.txt
+++ b/tests~/SnapshotTests.VerifySampleDump_dumpName=SubscribeApplied.verified.txt
@@ -661,13 +661,19 @@
     ReducerRequestTracker: {
       requestsAwaitingResponse: 9
     },
-    OneOffRequestTracker: {},
     SubscriptionRequestTracker: {},
+    OneOffRequestTracker: {},
     AllReducersTracker: {
       sampleCount: 9
     },
+    ParseMessageQueueTracker: {
+      sampleCount: 15
+    },
     ParseMessageTracker: {
-      sampleCount: 14
+      sampleCount: 15
+    },
+    ApplyMessageQueueTracker: {
+      sampleCount: 15
     },
     ApplyMessageTracker: {
       sampleCount: 15

--- a/tests~/SnapshotTests.cs
+++ b/tests~/SnapshotTests.cs
@@ -496,7 +496,7 @@ SampleUserInsert("k5DMlKmWjfbSl7qmZQOok7HDSwsAJopRSJjdlUsNogs=", null, true)
             client.OnMessageReceived(sample, DateTime.UtcNow);
             // Wait for this message to be picked up by the background thread, preprocessed and stored in the preprocessed queue.
             // Otherwise we'll get inconsistent output order between test reruns.
-            while (!client.HasPreProcessedMessage) { }
+            while (!client.HasMessageToApply) { }
             // Once the message is in the preprocessed queue, we can invoke Update() to handle events on the main thread.
             client.FrameTick();
         }


### PR DESCRIPTION
## Description of Changes
Addresses https://github.com/clockworklabs/SpacetimeDBPrivate/issues/1786 and https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/issues/329. Marks messages as parsed from the background parsing thread, and then marks them as applied using a separate tracker once they are applied.

## API

 - [ ] This is an API breaking change to the SDK

*If the API is breaking, please state below what will break*

## Requires SpacetimeDB PRs

## Testsuite

SpacetimeDB branch name: master

## Testing

- [x] Testing against Bitcraft