### PR TITLE
Bump versions to 1.2.1

### DIFF
--- a/SpacetimeDB.ClientSDK.csproj
+++ b/SpacetimeDB.ClientSDK.csproj
@@ -16,8 +16,8 @@
     <PackageIcon>logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk</RepositoryUrl>
-    <AssemblyVersion>1.2.0</AssemblyVersion>
-    <Version>1.2.0</Version>
+    <AssemblyVersion>1.2.1</AssemblyVersion>
+    <Version>1.2.1</Version>
     <DefaultItemExcludes>$(DefaultItemExcludes);*~/**</DefaultItemExcludes>
     <!-- We want to save DLLs for Unity which doesn't support NuGet. -->
     <RestorePackagesPath>packages</RestorePackagesPath>

--- a/examples~/quickstart-chat/server/StdbModule.csproj
+++ b/examples~/quickstart-chat/server/StdbModule.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Runtime" Version="1.1.*" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="1.2.*" />
   </ItemGroup>
 
 </Project>

--- a/examples~/regression-tests/server/StdbModule.csproj
+++ b/examples~/regression-tests/server/StdbModule.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Runtime" Version="1.1.*" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="1.2.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description of Changes
These version bumps were supposed to happen in https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/pull/332, but apparently I messed something up while I was switching branches.

## API

 - [ ] This is an API breaking change to the SDK

No breaking changes

## Requires SpacetimeDB PRs
None.

## Testsuite
SpacetimeDB branch name: master

## Testing
CI only