### PR TITLE
Bump Unity package version to 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.clockworklabs.spacetimedbsdk",
   "displayName": "SpacetimeDB SDK",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The SpacetimeDB Client SDK is a software development kit (SDK) designed to interact with and manipulate SpacetimeDB modules..",
   "keywords": [],
   "author": {


### PR DESCRIPTION
## Description of Changes
Missed in https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/pull/333.

We should update the 1.2.1 tag and the `release/latest` branch after this.

## API

 - [ ] This is an API breaking change to the SDK

Nope

## Requires SpacetimeDB PRs
None

## Testsuite
SpacetimeDB branch name: master

## Testing
CI only