### PR TITLE
Add `tools~/upgrade-version.py`

### DIFF
--- a/tools~/update-version.py
+++ b/tools~/update-version.py
@@ -1,0 +1,78 @@
+import os
+import re
+import sys
+import json
+import argparse
+
+def update_csproj_file(path, version):
+    with open(path, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+
+    updated_lines = []
+    version_prefix = '.'.join(version.split('.')[:2]) + '.*'
+    version_tag_written = set()
+
+    for i, line in enumerate(lines):
+        # Update PackageReference for SpacetimeDB.*
+        updated_line = re.sub(
+            r'(<PackageReference[^>]*Include="SpacetimeDB\.[^"]*"[^>]*Version=")[^"]*(")',
+            rf'\g<1>{version_prefix}\g<2>',
+            line
+        )
+
+        for tag in ('Version', 'AssemblyVersion'):
+            if re.search(rf'<{tag}>.*</{tag}>', updated_line.strip()):
+                updated_line = re.sub(
+                    rf'(<{tag}>).*(</{tag}>)',
+                    rf'\g<1>{version}\g<2>',
+                    updated_line
+                )
+                version_tag_written.add(tag)
+
+        updated_lines.append(updated_line)
+
+    with open(path, 'w', encoding='utf-8') as f:
+        f.writelines(updated_lines)
+    print(f"Updated: {path}")
+
+def update_all_csproj_files(version):
+    for root, _, files in os.walk('.'):
+        for file in files:
+            if file.endswith('.csproj'):
+                update_csproj_file(os.path.join(root, file), version)
+
+def update_package_json(version):
+    path = 'package.json'
+    if os.path.exists(path):
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        data['version'] = version
+        with open(path, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2)
+            f.write('\n')  # ensure trailing newline
+        print(f"Updated version in {path} to {version}")
+    else:
+        print("package.json not found.")
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Update version numbers in .csproj files and package.json',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python update-version.py 1.2.3
+  python update-version.py --version 1.2.3
+        """
+    )
+    parser.add_argument(
+        'version',
+        help='Version number to set (e.g., 1.2.3)'
+    )
+
+    args = parser.parse_args()
+
+    update_all_csproj_files(args.version)
+    update_package_json(args.version)
+
+if __name__ == '__main__':
+    main()

--- a/tools~/upgrade-version.py
+++ b/tools~/upgrade-version.py
@@ -60,8 +60,8 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  python update-version.py 1.2.3
-  python update-version.py --version 1.2.3
+  python upgrade-version.py 1.2.3
+  python upgrade-version.py --version 1.2.3
         """
     )
     parser.add_argument(


### PR DESCRIPTION
## Description of Changes
I'm tired of messing up version updates. I "vibecoded" a script to do it.

## API

 - [ ] This is an API breaking change to the SDK

No. No changes to runtime code.

## Requires SpacetimeDB PRs
None

## Testsuite
SpacetimeDB branch name: master

## Testing
```
$ python3 tools~/update-version.py 1.1.1
Updated: ./SpacetimeDB.ClientSDK.csproj
Updated: ./tests~/tests.csproj
Updated: ./examples~/regression-tests/server/StdbModule.csproj
Updated: ./examples~/regression-tests/client/client.csproj
Updated: ./examples~/quickstart-chat/server/StdbModule.csproj
Updated: ./examples~/quickstart-chat/client/client.csproj
Updated version in package.json to 1.1.1

$ git diff -U1
diff --git a/SpacetimeDB.ClientSDK.csproj b/SpacetimeDB.ClientSDK.csproj
index 5248df6..b3ca7e8 100644
--- a/SpacetimeDB.ClientSDK.csproj
+++ b/SpacetimeDB.ClientSDK.csproj
@@ -18,4 +18,4 @@
     <RepositoryUrl>https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk</RepositoryUrl>
-    <AssemblyVersion>1.2.1</AssemblyVersion>
-    <Version>1.2.1</Version>
+    <AssemblyVersion>1.1.1</AssemblyVersion>
+    <Version>1.1.1</Version>
     <DefaultItemExcludes>$(DefaultItemExcludes);*~/**</DefaultItemExcludes>
@@ -27,3 +27,3 @@
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.BSATN.Runtime" Version="1.2.*" />
+    <PackageReference Include="SpacetimeDB.BSATN.Runtime" Version="1.1.*" />
 
diff --git a/examples~/quickstart-chat/server/StdbModule.csproj b/examples~/quickstart-chat/server/StdbModule.csproj
index 0513a81..f290d22 100644
--- a/examples~/quickstart-chat/server/StdbModule.csproj
+++ b/examples~/quickstart-chat/server/StdbModule.csproj
@@ -16,3 +16,3 @@
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Runtime" Version="1.2.*" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="1.1.*" />
   </ItemGroup>
diff --git a/examples~/regression-tests/server/StdbModule.csproj b/examples~/regression-tests/server/StdbModule.csproj
index c6b1cba..3284863 100644
--- a/examples~/regression-tests/server/StdbModule.csproj
+++ b/examples~/regression-tests/server/StdbModule.csproj
@@ -10,3 +10,3 @@
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Runtime" Version="1.2.*" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="1.1.*" />
   </ItemGroup>
diff --git a/package.json b/package.json
index 7839151..a627246 100644
--- a/package.json
+++ b/package.json
@@ -3,3 +3,3 @@
   "displayName": "SpacetimeDB SDK",
-  "version": "1.2.1",
+  "version": "1.1.1",
   "description": "The SpacetimeDB Client SDK is a software development kit (SDK) designed to interact with and manipulate SpacetimeDB modules..",
```