### PR TITLE
Update WebGL message queue to 1.2.1 format

### DIFF
--- a/src/SpacetimeDBClient.cs
+++ b/src/SpacetimeDBClient.cs
@@ -421,7 +421,7 @@ namespace SpacetimeDB
 
 #if UNITY_WEBGL && !UNITY_EDITOR
                 yield return null;
-                while (_messageQueue.Count > 0)
+                while (_parseQueue.Count > 0)
 #endif
                 try
                 {


### PR DESCRIPTION
## Description of Changes
This is a fix for community bug https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/issues/340 that was the result of changes to SpacetimeDBClient code that missed changes to the WebGL build.

## API

 - [ ] This is an API breaking change to the SDK

## Requires SpacetimeDB PRs
- None

## Testsuite
SpacetimeDB branch name: master

## Testing

- [X] Tested changes against Blackholio running under a Unity WebGL build
